### PR TITLE
tests(langchain-sdk): Update conftest to be able to run tests in local

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,7 +158,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
         # Wait for server to start
         # Retry logic with a timeout
         for _ in range(5):  # retries
-            time.sleep(4)
+            time.sleep(2)
             print("Checking if toolbox is successfully started...")
             if toolbox_server.poll() is None:
                 print("Toolbox server started successfully.")


### PR DESCRIPTION
[Getting an id token from metadata server](https://cloud.google.com/docs/authentication/get-id-token#metadata-server) does not work on local systems. This causes test failures for auth tests locally. This PR fixes the issue.

This unblocks https://b.corp.google.com/issues/385051620