### PR TITLE
feat: Add support for async token getters to ToolboxTool

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -335,6 +335,10 @@ async def resolve_value(
     """
     Asynchronously or synchronously resolves a given source to its value.
 
+    If the `source` is a coroutine function, it will be awaited.
+    If the `source` is a regular callable, it will be called.
+    Otherwise (if it's not a callable), the `source` itself is returned directly.
+
     Args:
         source: The value, a callable returning a value, or a callable
                 returning an awaitable value.
@@ -342,6 +346,7 @@ async def resolve_value(
     Returns:
         The resolved value.
     """
+
     if asyncio.iscoroutinefunction(source):
         return await source()
     elif callable(source):

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -181,16 +181,12 @@ class ToolboxTool:
 
         # apply bounded parameters
         for param, value in self.__bound_parameters.items():
-            if asyncio.iscoroutinefunction(value):
-                value = await value()
-            elif callable(value):
-                value = value()
-            payload[param] = value
+            payload[param] = await get_value(value)
 
         # create headers for auth services
         headers = {}
         for auth_service, token_getter in self.__auth_service_token_getters.items():
-            headers[f"{auth_service}_token"] = token_getter()
+            headers[f"{auth_service}_token"] = await get_value(token_getter)
 
         async with self.__session.post(
             self.__url,
@@ -330,3 +326,12 @@ def params_to_pydantic_model(
             ),
         )
     return create_model(tool_name, **field_definitions)
+
+
+async def get_value(func: Callable[[], Any]) -> Any:
+    """Asynchronously or synchronously gets the value from a callable."""
+    if asyncio.iscoroutinefunction(func):
+        return await func()
+    elif callable(func):
+        return func()
+    return func

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -166,6 +166,20 @@ class TestAuth:
         response = await auth_tool(id="2")
         assert "row2" in response
 
+    @pytest.mark.asyncio
+    async def test_run_tool_async_auth(toolbox: ToolboxClient, auth_token1: str):
+        """Tests running a tool with correct auth using an async token getter."""
+        tool = await toolbox.load_tool("get-row-by-id-auth")
+
+        async def get_token_asynchronously():
+            return auth_token1
+
+        auth_tool = tool.add_auth_token_getters(
+            {"my-test-auth": get_token_asynchronously}
+        )
+        response = await auth_tool(id="2")
+        assert "row2" in response
+
     async def test_run_tool_param_auth_no_auth(self, toolbox: ToolboxClient):
         """Tests running a tool with a param requiring auth, without auth."""
         tool = await toolbox.load_tool("get-row-by-email-auth")

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -167,7 +167,7 @@ class TestAuth:
         assert "row2" in response
 
     @pytest.mark.asyncio
-    async def test_run_tool_async_auth(toolbox: ToolboxClient, auth_token1: str):
+    async def test_run_tool_async_auth(self, toolbox: ToolboxClient, auth_token1: str):
         """Tests running a tool with correct auth using an async token getter."""
         tool = await toolbox.load_tool("get-row-by-id-auth")
 


### PR DESCRIPTION
Previously we were only supporting sync token getters. Adding support for async getters could be beneficial performance-wise.