### PR TITLE
fix: Export ToolboxTool from toolbox-core for toolbox-langchain integration

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/__init__.py
+++ b/packages/toolbox-core/src/toolbox_core/__init__.py
@@ -14,5 +14,8 @@
 
 from .client import ToolboxClient
 from .sync_client import ToolboxSyncClient
+from .tool import ToolboxTool
+from .sync_tool import ToolboxSyncTool
 
-__all__ = ["ToolboxClient", "ToolboxSyncClient"]
+
+__all__ = ["ToolboxClient", "ToolboxSyncClient", "ToolboxTool", "ToolboxSyncTool"]

--- a/packages/toolbox-core/src/toolbox_core/__init__.py
+++ b/packages/toolbox-core/src/toolbox_core/__init__.py
@@ -14,8 +14,7 @@
 
 from .client import ToolboxClient
 from .sync_client import ToolboxSyncClient
-from .tool import ToolboxTool
 from .sync_tool import ToolboxSyncTool
-
+from .tool import ToolboxTool
 
 __all__ = ["ToolboxClient", "ToolboxSyncClient", "ToolboxTool", "ToolboxSyncTool"]


### PR DESCRIPTION
The `ToolboxTool` class within `toolbox-langchain` relies on importing the `ToolboxTool` class from the underlying `toolbox-core` library.

This change exports the `ToolboxTool` class from `toolbox-core`, making it easier to access it from `toolbox-langchain`.