### PR TITLE
fix(toolbox-core): Prevent rebinding of parameters in ToolboxTool

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -316,12 +316,13 @@ class ToolboxTool:
         """
         param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
-            if name not in param_names:
-                raise Exception(f"unable to bind parameters: no parameter named {name}")
             if name in self.__bound_parameters:
                 raise ValueError(
                     f"cannot re-bind parameter: parameter '{name}' is already bound"
                 )
+
+            if name not in param_names:
+                raise Exception(f"unable to bind parameters: no parameter named {name}")
 
         new_params = []
         for p in self.__params:

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -314,7 +314,10 @@ class ToolboxTool:
          Returns:
              A new ToolboxTool instance with the specified parameters bound.
         """
+        param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
+            if name not in param_names:
+                raise Exception(f"unable to bind parameters: no parameter named {name}")
             if name in self.__bound_parameters:
                 raise ValueError(
                     f"cannot re-bind parameter: parameter '{name}' is already bound"

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -314,10 +314,11 @@ class ToolboxTool:
          Returns:
              A new ToolboxTool instance with the specified parameters bound.
         """
-        param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
-            if name not in param_names:
-                raise Exception(f"unable to bind parameters: no parameter named {name}")
+            if name in self.__bound_parameters:
+                raise ValueError(
+                    f"cannot re-bind parameter: parameter '{name}' is already bound"
+                )
 
         new_params = []
         for p in self.__params:

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -460,7 +460,9 @@ class TestBoundParameter:
         with pytest.raises(ValueError) as e:
             tool_with_bound_param.bind_parameters({"argA": lambda: 20})
 
-        assert "cannot re-bind parameter: parameter 'argA' is already bound" in str(e.value)
+        assert "cannot re-bind parameter: parameter 'argA' is already bound" in str(
+            e.value
+        )
 
     @pytest.mark.asyncio
     async def test_bind_param_static_value_success(self, tool_name, client):

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -444,7 +444,9 @@ class TestBoundParameter:
         assert "argA" not in bound_tool_once.__signature__.parameters
         assert "argB" in bound_tool_once.__signature__.parameters
 
-        expected_error_msg = "cannot re-bind parameter: parameter 'argA' is already bound"
+        expected_error_msg = (
+            "cannot re-bind parameter: parameter 'argA' is already bound"
+        )
         with pytest.raises(ValueError, match=expected_error_msg):
             bound_tool_once.bind_parameters({"argA": 10})
 

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -454,6 +454,9 @@ class TestBoundParameter:
 
         tool_with_bound_param = tool.bind_parameters({"argA": lambda: 10})
 
+        assert len(tool_with_bound_param.__signature__.parameters) == 1
+        assert "argA" not in tool_with_bound_param.__signature__.parameters
+
         with pytest.raises(ValueError) as e:
             tool_with_bound_param.bind_parameters({"argA": lambda: 20})
 


### PR DESCRIPTION
This pull request updates the `bind_parameters` helper function within the `ToolboxTool` of the `toolbox-core` package to enhance parameter binding management.

* The helper now throws an explicit error if a user attempts to bind a parameter that has already been bound. This change aims to prevent unexpected behavior and improve the clarity of parameter assignments.
* The error that previously occurred when a user tried to bind a parameter not present in the tool's schema has been removed. This validation will be handled by a `strict` mode implementation in a future PR.