### PR TITLE
fix: Ensure `__parse_tool` returns correct `used_auth_keys`

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -79,7 +79,7 @@ class ToolboxClient:
             else:  # regular parameter
                 params.append(p)
 
-        authn_params, _ = identify_required_authn_params(
+        authn_params, used_auth_keys = identify_required_authn_params(
             authn_params, auth_token_getters.keys()
         )
 
@@ -97,9 +97,6 @@ class ToolboxClient:
         )
 
         used_bound_keys = set(bound_params.keys())
-        used_auth_keys: set[str] = set()
-        for required_sources in authn_params.values():
-            used_auth_keys.update(required_sources)
 
         return tool, used_auth_keys, used_bound_keys
 

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -316,6 +316,8 @@ class ToolboxTool:
         """
         param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
+            if name not in param_names:
+                raise Exception(f"unable to bind parameters: no parameter named {name}")
             if name in self.__bound_parameters:
                 raise ValueError(
                     f"cannot re-bind parameter: parameter '{name}' is already bound"

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -316,8 +316,6 @@ class ToolboxTool:
         """
         param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
-            if name not in param_names:
-                raise Exception(f"unable to bind parameters: no parameter named {name}")
             if name in self.__bound_parameters:
                 raise ValueError(
                     f"cannot re-bind parameter: parameter '{name}' is already bound"


### PR DESCRIPTION
This PR refactors `__parse_tool` to accurately determine and return the `used_auth_keys` value.

Investigation revealed that the previously incorrect value was not referenced elsewhere, meaning this bug did not manifest as an active issue. However, this correction enhances the reliability of `__parse_tool` for any future use cases.

> [!NOTE]
> Unit tests for the underlying helper function that identifies these used auth keys, including tests for the correct values, had already been added in #203. As this PR's change corrects a value that wasn't actively tested or used, no unit test modifications are needed here.