### PR TITLE
feat: Implement strict validation for client while loading tools

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -157,6 +157,9 @@ class ToolboxClient:
                 for execution. The specific arguments and behavior of the callable
                 depend on the tool itself.
 
+        Raises:
+            ValueError: If the loaded tool instance fails to utilize at least
+                one provided parameter or auth token (if any provided).
         """
         # Resolve client headers
         resolved_headers = {
@@ -174,13 +177,33 @@ class ToolboxClient:
         if name not in manifest.tools:
             # TODO: Better exception
             raise Exception(f"Tool '{name}' not found!")
-        tool, _, _ = self.__parse_tool(
+        tool, used_auth_keys, used_bound_keys = self.__parse_tool(
             name,
             manifest.tools[name],
             auth_token_getters,
             bound_params,
             self.__client_headers,
         )
+
+        provided_auth_keys = set(auth_token_getters.keys())
+        provided_bound_keys = set(bound_params.keys())
+
+        unused_auth = provided_auth_keys - used_auth_keys
+        unused_bound = provided_bound_keys - used_bound_keys
+
+        if unused_auth or unused_bound:
+            error_messages = []
+            if unused_auth:
+                error_messages.append(
+                    f"unused auth tokens: {', '.join(unused_auth)}"
+                )
+            if unused_bound:
+                error_messages.append(
+                    f"unused bound parameters: {', '.join(unused_bound)}"
+                )
+            raise ValueError(
+                f"Validation failed for tool '{name}': { '; '.join(error_messages) }."
+            )
 
         return tool
 
@@ -189,40 +212,98 @@ class ToolboxClient:
         name: Optional[str] = None,
         auth_token_getters: dict[str, Callable[[], str]] = {},
         bound_params: Mapping[str, Union[Callable[[], Any], Any]] = {},
+        strict: bool = False,
     ) -> list[ToolboxTool]:
         """
         Asynchronously fetches a toolset and loads all tools defined within it.
 
         Args:
-            name: Name of the toolset to load tools.
+            name: Name of the toolset to load. If None, loads the default toolset.
             auth_token_getters: A mapping of authentication service names to
                 callables that return the corresponding authentication token.
             bound_params: A mapping of parameter names to bind to specific values or
                 callables that are called to produce values as needed.
+            strict: If True, raises an error if *any* loaded tool instance fails
+                to utilize at least one provided parameter or auth token (if any
+                provided). If False (default), raises an error only if a
+                user-provided parameter or auth token cannot be applied to *any*
+                loaded tool across the set.
 
         Returns:
             list[ToolboxTool]: A list of callables, one for each tool defined
             in the toolset.
+
+        Raises:
+            ValueError: If validation fails based on the `strict` flag.
         """
+
         # Resolve client headers
         original_headers = self.__client_headers
         resolved_headers = {
             header_name: await resolve_value(original_headers[header_name])
             for header_name in original_headers
         }
-        # Request the definition of the tool from the server
+        # Request the definition of the toolset from the server
         url = f"{self.__base_url}/api/toolset/{name or ''}"
         async with self.__session.get(url, headers=resolved_headers) as response:
             json = await response.json()
         manifest: ManifestSchema = ManifestSchema(**json)
 
-        # parse each tools name and schema into a list of ToolboxTools
-        tools = [
-            self.__parse_tool(
-                n, s, auth_token_getters, bound_params, self.__client_headers
-            )[0]
-            for n, s in manifest.tools.items()
-        ]
+        tools: list[ToolboxTool] = []
+        overall_used_auth_keys: set[str] = set()
+        overall_used_bound_params: set[str] = set()
+        provided_auth_keys = set(auth_token_getters.keys())
+        provided_bound_keys = set(bound_params.keys())
+
+        # parse each tool's name and schema into a list of ToolboxTools
+        for tool_name, schema in manifest.tools.items():
+            tool, used_auth_keys, used_bound_keys = self.__parse_tool(
+                tool_name,
+                schema,
+                auth_token_getters,
+                bound_params,
+                self.__client_headers,
+            )
+            tools.append(tool)
+
+            if strict:
+                unused_auth = provided_auth_keys - used_auth_keys
+                unused_bound = provided_bound_keys - used_bound_keys
+                if unused_auth or unused_bound:
+                    error_messages = []
+                    if unused_auth:
+                        error_messages.append(
+                            f"unused auth tokens: {', '.join(unused_auth)}"
+                        )
+                    if unused_bound:
+                        error_messages.append(
+                            f"unused bound parameters: {', '.join(unused_bound)}"
+                        )
+                    raise ValueError(
+                        f"Validation failed for tool '{name}': { '; '.join(error_messages) }."
+                    )
+            else:
+                overall_used_auth_keys.update(used_auth_keys)
+                overall_used_bound_params.update(used_bound_keys)
+
+        if not strict:
+            unused_auth = provided_auth_keys - overall_used_auth_keys
+            unused_bound = provided_bound_keys - overall_used_bound_params
+
+            if unused_auth or unused_bound:
+                error_messages = []
+                if unused_auth:
+                    error_messages.append(
+                        f"unused auth tokens could not be applied to any tool: {', '.join(unused_auth)}"
+                    )
+                if unused_bound:
+                    error_messages.append(
+                        f"unused bound parameters could not be applied to any tool: {', '.join(unused_bound)}"
+                    )
+                raise ValueError(
+                    f"Validation failed for toolset '{name or 'default'}': { '; '.join(error_messages) }."
+                )
+
         return tools
 
     async def add_headers(

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -194,9 +194,7 @@ class ToolboxClient:
         if unused_auth or unused_bound:
             error_messages = []
             if unused_auth:
-                error_messages.append(
-                    f"unused auth tokens: {', '.join(unused_auth)}"
-                )
+                error_messages.append(f"unused auth tokens: {', '.join(unused_auth)}")
             if unused_bound:
                 error_messages.append(
                     f"unused bound parameters: {', '.join(unused_bound)}"

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -280,7 +280,7 @@ class ToolboxClient:
                             f"unused bound parameters: {', '.join(unused_bound)}"
                         )
                     raise ValueError(
-                        f"Validation failed for tool '{name}': { '; '.join(error_messages) }."
+                        f"Validation failed for tool '{tool_name}': { '; '.join(error_messages) }."
                     )
             else:
                 overall_used_auth_keys.update(used_auth_keys)

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -284,23 +284,22 @@ class ToolboxClient:
                 overall_used_auth_keys.update(used_auth_keys)
                 overall_used_bound_params.update(used_bound_keys)
 
-        if not strict:
-            unused_auth = provided_auth_keys - overall_used_auth_keys
-            unused_bound = provided_bound_keys - overall_used_bound_params
+        unused_auth = provided_auth_keys - overall_used_auth_keys
+        unused_bound = provided_bound_keys - overall_used_bound_params
 
-            if unused_auth or unused_bound:
-                error_messages = []
-                if unused_auth:
-                    error_messages.append(
-                        f"unused auth tokens could not be applied to any tool: {', '.join(unused_auth)}"
-                    )
-                if unused_bound:
-                    error_messages.append(
-                        f"unused bound parameters could not be applied to any tool: {', '.join(unused_bound)}"
-                    )
-                raise ValueError(
-                    f"Validation failed for toolset '{name or 'default'}': { '; '.join(error_messages) }."
+        if unused_auth or unused_bound:
+            error_messages = []
+            if unused_auth:
+                error_messages.append(
+                    f"unused auth tokens could not be applied to any tool: {', '.join(unused_auth)}"
                 )
+            if unused_bound:
+                error_messages.append(
+                    f"unused bound parameters could not be applied to any tool: {', '.join(unused_bound)}"
+                )
+            raise ValueError(
+                f"Validation failed for toolset '{name or 'default'}': { '; '.join(error_messages) }."
+            )
 
         return tools
 

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -316,6 +316,8 @@ class ToolboxTool:
         """
         param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
+            if name not in param_names:
+                raise Exception(f"unable to bind parameters: no parameter named {name}")
             if name in self.__bound_parameters:
                 raise ValueError(
                     f"cannot re-bind parameter: parameter '{name}' is already bound"

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -316,8 +316,6 @@ class ToolboxTool:
         """
         param_names = set(p.name for p in self.__params)
         for name in bound_params.keys():
-            if name not in param_names:
-                raise Exception(f"unable to bind parameters: no parameter named {name}")
             if name in self.__bound_parameters:
                 raise ValueError(
                     f"cannot re-bind parameter: parameter '{name}' is already bound"

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -66,6 +66,7 @@ def test_tool_auth():
         ],
     )
 
+
 @pytest.fixture
 def tool_schema_minimal():
     """A tool with no parameters, no auth."""
@@ -74,6 +75,7 @@ def tool_schema_minimal():
         parameters=[],
     )
 
+
 @pytest.fixture
 def tool_schema_requires_auth_X():
     """A tool requiring 'auth_service_X'."""
@@ -81,7 +83,7 @@ def tool_schema_requires_auth_X():
         description="Tool Requiring Auth X",
         parameters=[
             ParameterSchema(
-                name="auth_param_X", #
+                name="auth_param_X",  #
                 type="string",
                 description="Auth X Token",
                 authSources=["auth_service_X"],
@@ -100,6 +102,7 @@ def tool_schema_with_param_P():
             ParameterSchema(name="param_P", type="string", description="Parameter P"),
         ],
     )
+
 
 # --- Helper Functions for Mocking ---
 
@@ -580,7 +583,9 @@ class TestUnusedParameterValidation:
         The tool (tool_schema_minimal) does not declare any authSources.
         """
         tool_name = "minimal_tool_for_unused_auth"
-        mock_tool_load(aioresponses, tool_name, tool_schema_minimal, base_url=TEST_BASE_URL)
+        mock_tool_load(
+            aioresponses, tool_name, tool_schema_minimal, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -601,7 +606,9 @@ class TestUnusedParameterValidation:
         provided. The tool (tool_schema_minimal) has no parameters to bind.
         """
         tool_name = "minimal_tool_for_unused_bound"
-        mock_tool_load(aioresponses, tool_name, tool_schema_minimal, base_url=TEST_BASE_URL)
+        mock_tool_load(
+            aioresponses, tool_name, tool_schema_minimal, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -621,7 +628,9 @@ class TestUnusedParameterValidation:
         are provided.
         """
         tool_name = "minimal_tool_for_unused_both"
-        mock_tool_load(aioresponses, tool_name, tool_schema_minimal, base_url=TEST_BASE_URL)
+        mock_tool_load(
+            aioresponses, tool_name, tool_schema_minimal, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -647,7 +656,9 @@ class TestUnusedParameterValidation:
         toolset_name = "strict_set_single_tool_unused_auth"
         tool_A_name = "tool_A_minimal"
         tools_dict = {tool_A_name: tool_schema_minimal}
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -677,7 +688,9 @@ class TestUnusedParameterValidation:
             tool_minimal_name: tool_schema_minimal,
             tool_auth_X_name: tool_schema_requires_auth_X,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -708,7 +721,9 @@ class TestUnusedParameterValidation:
             tool_auth_X_name: tool_schema_requires_auth_X,
             tool_minimal_name: tool_schema_minimal,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -722,6 +737,7 @@ class TestUnusedParameterValidation:
                     },
                     strict=True,
                 )
+
     @pytest.mark.asyncio
     async def test_load_toolset_strict_one_tool_unused_bound_raises(
         self, aioresponses, tool_schema_minimal
@@ -733,7 +749,9 @@ class TestUnusedParameterValidation:
         toolset_name = "strict_set_single_tool_unused_bound"
         tool_A_name = "tool_A_minimal_for_bound"
         tools_dict = {tool_A_name: tool_schema_minimal}
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -762,7 +780,9 @@ class TestUnusedParameterValidation:
             tool_minimal_name: tool_schema_minimal,
             tool_param_P_name: tool_schema_with_param_P,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -793,7 +813,9 @@ class TestUnusedParameterValidation:
             tool_param_P_name: tool_schema_with_param_P,
             tool_minimal_name: tool_schema_minimal,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -808,8 +830,6 @@ class TestUnusedParameterValidation:
                     strict=True,
                 )
 
-
-
     @pytest.mark.asyncio
     async def test_load_toolset_strict_with_unused_auth_and_bound_raises_error(
         self, aioresponses, tool_schema_minimal
@@ -822,7 +842,9 @@ class TestUnusedParameterValidation:
         toolset_name = "strict_set_unused_both_minimal_tool"
         tool_minimal_name = "minimal_for_both_strict"
         tools_dict = {tool_minimal_name: tool_schema_minimal}
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -851,7 +873,9 @@ class TestUnusedParameterValidation:
             "auth_tool": tool_schema_requires_auth_X,
             "minimal_tool_in_set": tool_schema_minimal,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -880,7 +904,9 @@ class TestUnusedParameterValidation:
             "param_P_tool_in_set": tool_schema_with_param_P,
             "minimal_tool_in_set_bound": tool_schema_minimal,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -909,7 +935,9 @@ class TestUnusedParameterValidation:
             "auth_tool_for_both": tool_schema_requires_auth_X,
             "param_P_tool_for_both": tool_schema_with_param_P,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -928,7 +956,7 @@ class TestUnusedParameterValidation:
                     },
                     strict=False,
                 )
-    
+
     @pytest.mark.asyncio
     async def test_load_toolset_non_strict_default_name_globally_unused_auth(
         self, aioresponses, tool_schema_minimal
@@ -940,7 +968,9 @@ class TestUnusedParameterValidation:
         toolset_name = None
         expected_error_toolset_name = "default"
         tools_dict = {"some_minimal_tool": tool_schema_minimal}
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             with pytest.raises(
@@ -949,10 +979,11 @@ class TestUnusedParameterValidation:
             ):
                 await client.load_toolset(
                     name=toolset_name,
-                    auth_token_getters={"globally_unused_auth_default": lambda: "token"},
+                    auth_token_getters={
+                        "globally_unused_auth_default": lambda: "token"
+                    },
                     strict=False,
                 )
-
 
     @pytest.mark.asyncio
     async def test_load_toolset_non_strict_partially_used_auth_succeeds(
@@ -967,7 +998,9 @@ class TestUnusedParameterValidation:
             "auth_tool_partial": tool_schema_requires_auth_X,
             "minimal_tool_partial": tool_schema_minimal,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             await client.load_toolset(
@@ -975,7 +1008,6 @@ class TestUnusedParameterValidation:
                 auth_token_getters={"auth_service_X": lambda: "tokenX"},
                 strict=False,
             )
-
 
     @pytest.mark.asyncio
     async def test_load_toolset_non_strict_partially_used_bound_succeeds(
@@ -990,7 +1022,9 @@ class TestUnusedParameterValidation:
             "param_P_tool_partial": tool_schema_with_param_P,
             "minimal_tool_partial_bound": tool_schema_minimal,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             await client.load_toolset(
@@ -998,7 +1032,6 @@ class TestUnusedParameterValidation:
                 bound_params={"param_P": "valueP"},
                 strict=False,
             )
-
 
     @pytest.mark.asyncio
     async def test_load_toolset_non_strict_partially_used_auth_and_bound_succeeds(
@@ -1013,7 +1046,9 @@ class TestUnusedParameterValidation:
             "auth_tool_for_both": tool_schema_requires_auth_X,
             "param_P_tool_for_both": tool_schema_with_param_P,
         }
-        mock_toolset_load(aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL)
+        mock_toolset_load(
+            aioresponses, toolset_name, tools_dict, base_url=TEST_BASE_URL
+        )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
             await client.load_toolset(

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -133,11 +133,14 @@ class TestAuth:
         self, toolbox: ToolboxClient, auth_token2: str
     ):
         """Tests running a tool that doesn't require auth, with auth provided."""
-        tool = await toolbox.load_tool(
-            "get-row-by-id", auth_token_getters={"my-test-auth": lambda: auth_token2}
-        )
-        response = await tool(id="2")
-        assert "row2" in response
+
+        with pytest.raises(
+            ValueError,
+            match=rf"Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
+        ):
+            await toolbox.load_tool(
+                "get-row-by-id", auth_token_getters={"my-test-auth": lambda: auth_token2}
+            )
 
     async def test_run_tool_no_auth(self, toolbox: ToolboxClient):
         """Tests running a tool requiring auth without providing auth."""

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -139,7 +139,8 @@ class TestAuth:
             match=rf"Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
         ):
             await toolbox.load_tool(
-                "get-row-by-id", auth_token_getters={"my-test-auth": lambda: auth_token2}
+                "get-row-by-id",
+                auth_token_getters={"my-test-auth": lambda: auth_token2},
             )
 
     async def test_run_tool_no_auth(self, toolbox: ToolboxClient):

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -121,7 +121,8 @@ class TestAuth:
             match=rf"Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
         ):
             toolbox.load_tool(
-                "get-row-by-id", auth_token_getters={"my-test-auth": lambda: auth_token2}
+                "get-row-by-id",
+                auth_token_getters={"my-test-auth": lambda: auth_token2},
             )
 
     def test_run_tool_no_auth(self, toolbox: ToolboxSyncClient):

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -115,11 +115,14 @@ class TestAuth:
         self, toolbox: ToolboxSyncClient, auth_token2: str
     ):
         """Tests running a tool that doesn't require auth, with auth provided."""
-        tool = toolbox.load_tool(
-            "get-row-by-id", auth_token_getters={"my-test-auth": lambda: auth_token2}
-        )
-        response = tool(id="2")
-        assert "row2" in response
+
+        with pytest.raises(
+            ValueError,
+            match=rf"Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
+        ):
+            toolbox.load_tool(
+                "get-row-by-id", auth_token_getters={"my-test-auth": lambda: auth_token2}
+            )
 
     def test_run_tool_no_auth(self, toolbox: ToolboxSyncClient):
         """Tests running a tool requiring auth without providing auth."""


### PR DESCRIPTION
This pull request introduces a `strict` mode to the `load_toolset` method and refines the validation behavior of the `load_tool` method.

## Benefits
* Ensures tools are configured as intended and are using all provided authentication mechanisms and parameters.
* Helps identify misconfigurations or unused inputs during the tool loading phase, rather than leading to potential runtime issues.
* Makes it explicit when a tool is not interacting with expected configurations.

## Changes

### `load_toolset(strict: bool = False)`

The `load_toolset` method now includes an optional `strict` flag:

* `strict = False` (Default Behavior):

  * Validation will fail (raising a `ValueError`) if at least one authentication token getter (from the `auth_token_getters` provided) or at least one bound parameter (from the `bound_params` provided) is not utilized by any of the tools loaded within the toolset. This ensures that all globally provided configurations find a consumer within the set.

* `strict = True`:

  * Validation becomes significantly more stringent on a per-tool basis. The method will fail if any individual tool loaded within the toolset does not utilize all of the globally provided authentication token getters and all of the globally provided bound parameters.
  * This mode ensures that every tool explicitly engages with every piece of shared configuration passed during the `load_toolset` call.

### `load_tool()`

* The `strict` flag has been intentionally omitted from the `load_tool` method.
* The validation for `load_tool` is now standardized to be inherently strict: the single loaded tool must utilize all provided auth token getters and all provided bound parameters.
* This decision was made because `load_tool` processes only one tool at a time. In this context, the nuanced behaviors of `strict = True` versus `strict = False` (as defined for `load_toolset`) do not apply; the expectation for a single tool is always full utilization of its provided configurations.

## Implementation
The validation logic leverages the `used_auth_keys` and `used_bound_keys` values returned by the internal `__parse_tool` helper function. This information indicates which specific auth token getters and bound parameters are actively used by each processed tool.

> [!NOTE]
> The `strict` flag available in `load_toolset` is a runtime parameter that governs the validation behavior during the loading process. It is not persisted as part of the tool's loaded configuration or state.
> This is because at the level of an individual tool's direct configuration (e.g., if one were to add an auth token getter directly to a single tool instance), the "strictness" is inherent: that single tool would naturally be expected to use the configuration specifically provided to it. This aligns with the always-strict validation now enforced by the `load_tool` method.