### PR TITLE
feat(toolbox-core)!: Align toolbox core's bind params API with orchestration packages

### DIFF
--- a/packages/toolbox-core/README.md
+++ b/packages/toolbox-core/README.md
@@ -369,7 +369,7 @@ specific tool instance.
 toolbox = ToolboxClient("http://127.0.0.1:5000")
 tool = await toolbox.load_tool("my-tool")
 
-bound_tool = tool.bind_parameters({"param": "value"})
+bound_tool = tool.bind_params({"param": "value"})
 ```
 
 ### Option B: Binding Parameters While Loading Tools

--- a/packages/toolbox-core/src/toolbox_core/sync_tool.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_tool.py
@@ -153,7 +153,7 @@ class ToolboxSyncTool:
         new_async_tool = self.__async_tool.add_auth_token_getters(auth_token_getters)
         return ToolboxSyncTool(new_async_tool, self.__loop, self.__thread)
 
-    def bind_parameters(
+    def bind_params(
         self, bound_params: Mapping[str, Union[Callable[[], Any], Any]]
     ) -> "ToolboxSyncTool":
         """
@@ -167,5 +167,5 @@ class ToolboxSyncTool:
              A new ToolboxSyncTool instance with the specified parameters bound.
         """
 
-        new_async_tool = self.__async_tool.bind_parameters(bound_params)
+        new_async_tool = self.__async_tool.bind_params(bound_params)
         return ToolboxSyncTool(new_async_tool, self.__loop, self.__thread)

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -301,7 +301,7 @@ class ToolboxTool:
             required_authn_params=new_req_authn_params,
         )
 
-    def bind_parameters(
+    def bind_params(
         self, bound_params: Mapping[str, Union[Callable[[], Any], Any]]
     ) -> "ToolboxTool":
         """

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -442,7 +442,7 @@ class TestBoundParameter:
         assert len(tool.__signature__.parameters) == 2
         assert "argA" in tool.__signature__.parameters
 
-        tool = tool.bind_parameters({"argA": 5})
+        tool = tool.bind_params({"argA": 5})
 
         assert len(tool.__signature__.parameters) == 1
         assert "argA" not in tool.__signature__.parameters
@@ -458,7 +458,7 @@ class TestBoundParameter:
         assert len(tool.__signature__.parameters) == 2
         assert "argA" in tool.__signature__.parameters
 
-        tool = tool.bind_parameters({"argA": lambda: 5})
+        tool = tool.bind_params({"argA": lambda: 5})
 
         assert len(tool.__signature__.parameters) == 1
         assert "argA" not in tool.__signature__.parameters
@@ -468,20 +468,20 @@ class TestBoundParameter:
 
     @pytest.mark.asyncio
     async def test_bind_param_fail(self, tool_name, client):
-        """Tests 'bind_parameters' with a bound parameter that doesn't exist."""
+        """Tests 'bind_params' with a bound parameter that doesn't exist."""
         tool = await client.load_tool(tool_name)
 
         assert len(tool.__signature__.parameters) == 2
         assert "argA" in tool.__signature__.parameters
 
         with pytest.raises(Exception) as e:
-            tool.bind_parameters({"argC": lambda: 5})
+            tool.bind_params({"argC": lambda: 5})
         assert "unable to bind parameters: no parameter named argC" in str(e.value)
 
     @pytest.mark.asyncio
     async def test_rebind_param_fail(self, tool_name, client):
         """
-        Tests that 'bind_parameters' fails when attempting to re-bind a
+        Tests that 'bind_params' fails when attempting to re-bind a
         parameter that has already been bound.
         """
         tool = await client.load_tool(tool_name)
@@ -489,13 +489,13 @@ class TestBoundParameter:
         assert len(tool.__signature__.parameters) == 2
         assert "argA" in tool.__signature__.parameters
 
-        tool_with_bound_param = tool.bind_parameters({"argA": lambda: 10})
+        tool_with_bound_param = tool.bind_params({"argA": lambda: 10})
 
         assert len(tool_with_bound_param.__signature__.parameters) == 1
         assert "argA" not in tool_with_bound_param.__signature__.parameters
 
         with pytest.raises(ValueError) as e:
-            tool_with_bound_param.bind_parameters({"argA": lambda: 20})
+            tool_with_bound_param.bind_params({"argA": lambda: 20})
 
         assert "cannot re-bind parameter: parameter 'argA' is already bound" in str(
             e.value
@@ -504,13 +504,13 @@ class TestBoundParameter:
     @pytest.mark.asyncio
     async def test_bind_param_static_value_success(self, tool_name, client):
         """
-        Tests bind_parameters method with a static value.
+        Tests bind_params method with a static value.
         """
 
         bound_value = "Test value"
 
         tool = await client.load_tool(tool_name)
-        bound_tool = tool.bind_parameters({"argB": bound_value})
+        bound_tool = tool.bind_params({"argB": bound_value})
 
         assert bound_tool is not tool
         assert "argB" not in bound_tool.__signature__.parameters
@@ -524,14 +524,14 @@ class TestBoundParameter:
     @pytest.mark.asyncio
     async def test_bind_param_sync_callable_value_success(self, tool_name, client):
         """
-        Tests bind_parameters method with a sync callable value.
+        Tests bind_params method with a sync callable value.
         """
 
         bound_value_result = True
         bound_sync_callable = Mock(return_value=bound_value_result)
 
         tool = await client.load_tool(tool_name)
-        bound_tool = tool.bind_parameters({"argB": bound_sync_callable})
+        bound_tool = tool.bind_params({"argB": bound_sync_callable})
 
         assert bound_tool is not tool
         assert "argB" not in bound_tool.__signature__.parameters
@@ -546,14 +546,14 @@ class TestBoundParameter:
     @pytest.mark.asyncio
     async def test_bind_param_async_callable_value_success(self, tool_name, client):
         """
-        Tests bind_parameters method with an async callable value.
+        Tests bind_params method with an async callable value.
         """
 
         bound_value_result = True
         bound_async_callable = AsyncMock(return_value=bound_value_result)
 
         tool = await client.load_tool(tool_name)
-        bound_tool = tool.bind_parameters({"argB": bound_async_callable})
+        bound_tool = tool.bind_params({"argB": bound_async_callable})
 
         assert bound_tool is not tool
         assert "argB" not in bound_tool.__signature__.parameters

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -105,7 +105,7 @@ class TestBindParams:
         self, toolbox: ToolboxClient, get_n_rows_tool: ToolboxTool
     ):
         """Bind a param to an existing tool."""
-        new_tool = get_n_rows_tool.bind_parameters({"num_rows": "3"})
+        new_tool = get_n_rows_tool.bind_params({"num_rows": "3"})
         response = await new_tool()
         assert isinstance(response, str)
         assert "row1" in response
@@ -117,7 +117,7 @@ class TestBindParams:
         self, toolbox: ToolboxClient, get_n_rows_tool: ToolboxTool
     ):
         """Bind a callable param to an existing tool."""
-        new_tool = get_n_rows_tool.bind_parameters({"num_rows": lambda: "3"})
+        new_tool = get_n_rows_tool.bind_params({"num_rows": lambda: "3"})
         response = await new_tool()
         assert isinstance(response, str)
         assert "row1" in response

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -88,7 +88,7 @@ class TestBindParams:
         self, toolbox: ToolboxSyncClient, get_n_rows_tool: ToolboxSyncTool
     ):
         """Bind a param to an existing tool."""
-        new_tool = get_n_rows_tool.bind_parameters({"num_rows": "3"})
+        new_tool = get_n_rows_tool.bind_params({"num_rows": "3"})
         response = new_tool()
         assert isinstance(response, str)
         assert "row1" in response
@@ -100,7 +100,7 @@ class TestBindParams:
         self, toolbox: ToolboxSyncClient, get_n_rows_tool: ToolboxSyncTool
     ):
         """Bind a callable param to an existing tool."""
-        new_tool = get_n_rows_tool.bind_parameters({"num_rows": lambda: "3"})
+        new_tool = get_n_rows_tool.bind_params({"num_rows": lambda: "3"})
         response = new_tool()
         assert isinstance(response, str)
         assert "row1" in response


### PR DESCRIPTION
This aligns with the other orchestration package naming, and is more precise and convenient.

`bind_parameters()` --> `bind_params()`

### Before
```py
bound_tool = tool.bind_parameters({"param": "value"})
```

### After
```py
bound_tool = tool.bind_params({"param": "value"})
```