### PR TITLE
fix: Add validation to ensure added auth token getters are used by the tool

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -309,7 +309,8 @@ class ToolboxTool:
 
         new_getters = dict(self.__auth_service_token_getters, **auth_token_getters)
 
-        # find the updated auth requirements
+        # find the updated required authn params, authz tokens and the auth
+        # token getters used
         new_req_authn_params, new_req_authz_tokens, used_auth_token_getters = (
             identify_auth_requirements(
                 self.__required_authn_params,

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -309,7 +309,7 @@ class ToolboxTool:
 
         new_getters = dict(self.__auth_service_token_getters, **auth_token_getters)
 
-        # find the updated requirements
+        # find the updated auth requirements
         new_req_authn_params, new_req_authz_tokens, used_auth_token_getters = (
             identify_auth_requirements(
                 self.__required_authn_params,
@@ -318,7 +318,12 @@ class ToolboxTool:
             )
         )
 
-        # TODO: Add validation for used_auth_token_getters
+        # ensure no auth token getter provided remains unused
+        unused_auth = set(incoming_services) - used_auth_token_getters
+        if unused_auth:
+            raise ValueError(
+                f"Authentication source(s) `{', '.join(unused_auth)}` unused by tool `{self.__name__}`."
+            )
 
         return self.__copy(
             # create a read-only map for updated getters, params and tokens that are still required

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -371,7 +371,6 @@ class TestAuth:
         ):
             authed_tool.add_auth_token_getters({AUTH_SERVICE: {}})
 
-
     @pytest.mark.asyncio
     async def test_add_auth_token_getters_missing_fail(self, tool_name, client):
         """

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -372,6 +372,35 @@ class TestAuth:
             authed_tool.add_auth_token_getters({AUTH_SERVICE: {}})
 
 
+    @pytest.mark.asyncio
+    async def test_add_auth_token_getters_missing_fail(self, tool_name, client):
+        """
+        Tests that adding a missing auth token getter raises ValueError.
+        """
+        AUTH_SERVICE = "xmy-auth-service"
+
+        tool = await client.load_tool(tool_name)
+
+        with pytest.raises(
+            ValueError,
+            match=f"Authentication source\(s\) \`{AUTH_SERVICE}\` unused by tool \`{tool_name}\`.",
+        ):
+            tool.add_auth_token_getters({AUTH_SERVICE: {}})
+
+    @pytest.mark.asyncio
+    async def test_constructor_getters_missing_fail(self, tool_name, client):
+        """
+        Tests that adding a missing auth token getter raises ValueError.
+        """
+        AUTH_SERVICE = "xmy-auth-service"
+
+        with pytest.raises(
+            ValueError,
+            match=f"Validation failed for tool '{tool_name}': unused auth tokens: {AUTH_SERVICE}.",
+        ):
+            await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
+
+
 class TestBoundParameter:
 
     @pytest.fixture


### PR DESCRIPTION
### Problem
Previously, the `ToolboxTool.add_auth_token_getters` method only validated against existing registered getters or conflicts with client headers. It did not verify if *all* the auth token getters provided were actually used or required by the specific tool instance they were being added to.

### Solution
This PR enhances the validation in `add_auth_token_getters`. It now leverages the `used_auth_token_getters` information returned by the existing `identify_required_authn_params` call. This allows the method to confirm that every getter passed in is genuinely required by the tool, raising an error if any are unused.

### Benefit
This ensures that only relevant auth token getters are attempted to be registered for a tool, preventing misconfigurations and human errors.

> [!NOTE]
> This validation aligns with the existing validation logic already present in the `ToolboxClient.load_tool` method, promoting a consistent approach to handling auth token getter requirements across the codebase.