### PR TITLE
fix(toolbox-core)!: Simplify add_headers to make it sync in async client

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -308,11 +308,11 @@ class ToolboxClient:
 
         return tools
 
-    async def add_headers(
+    def add_headers(
         self, headers: Mapping[str, Union[Callable, Coroutine, str]]
     ) -> None:
         """
-        Asynchronously Add headers to be included in each request sent through this client.
+        Add headers to be included in each request sent through this client.
 
         Args:
             headers: Headers to include in each request sent through this client.

--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -144,7 +144,7 @@ class ToolboxSyncClient:
         if not self.__loop or not self.__thread:
             raise ValueError("Background loop or thread cannot be None.")
 
-        async_tools = asyncio.run_coroutine_threadsafe(coro, self.__loop).result()  # type: ignore
+        async_tools = asyncio.run_coroutine_threadsafe(coro, self.__loop).result()
         return [
             ToolboxSyncTool(async_tool, self.__loop, self.__thread)
             for async_tool in async_tools
@@ -154,7 +154,7 @@ class ToolboxSyncClient:
         self, headers: Mapping[str, Union[Callable, Coroutine, str]]
     ) -> None:
         """
-        Synchronously Add headers to be included in each request sent through this client.
+        Add headers to be included in each request sent through this client.
 
         Args:
             headers: Headers to include in each request sent through this client.
@@ -162,10 +162,7 @@ class ToolboxSyncClient:
         Raises:
             ValueError: If any of the headers are already registered in the client.
         """
-        coro = self.__async_client.add_headers(headers)
-
-        # We have already created a new loop in the init method in case it does not already exist
-        asyncio.run_coroutine_threadsafe(coro, self.__loop).result()  # type: ignore
+        self.__async_client.add_headers(headers)
 
     def __enter__(self):
         """Enter the runtime context related to this client instance."""

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -257,27 +257,18 @@ class ToolboxTool:
             payload[param] = await resolve_value(value)
 
         # create headers for auth services
-        auth_headers = {}
+        headers = {}
         for auth_service, token_getter in self.__auth_service_token_getters.items():
-            auth_headers[self.__get_auth_header(auth_service)] = await resolve_value(
+            headers[self.__get_auth_header(auth_service)] = await resolve_value(
                 token_getter
             )
         for client_header_name, client_header_val in self.__client_headers.items():
-            auth_headers[client_header_name] = await resolve_value(client_header_val)
-
-        # ID tokens contain sensitive user information (claims). Transmitting
-        # these over HTTP exposes the data to interception and unauthorized
-        # access. Always use HTTPS to ensure secure communication and protect
-        # user privacy.
-        if auth_headers and not self.__url.startswith("https://"):
-            warn(
-                "Sending ID token over HTTP. User data may be exposed. Use HTTPS for secure communication."
-            )
+            headers[client_header_name] = await resolve_value(client_header_val)
 
         async with self.__session.post(
             self.__url,
             json=payload,
-            headers=auth_headers,
+            headers=headers,
         ) as resp:
             body = await resp.json()
             if resp.status < 200 or resp.status >= 300:

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -1443,7 +1443,7 @@ class TestClientHeaders:
         )
 
         async with ToolboxClient(TEST_BASE_URL) as client:
-            await client.add_headers(static_header)
+            client.add_headers(static_header)
             assert client._ToolboxClient__client_headers == static_header
 
             tool = await client.load_tool(tool_name)

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -398,35 +398,6 @@ class TestAuth:
             await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
 
 
-    @pytest.mark.asyncio
-    async def test_add_auth_token_getters_missing_fail(self, tool_name, client):
-        """
-        Tests that adding a missing auth token getter raises ValueError.
-        """
-        AUTH_SERVICE = "xmy-auth-service"
-
-        tool = await client.load_tool(tool_name)
-
-        with pytest.raises(
-            ValueError,
-            match=f"Authentication source\(s\) \`{AUTH_SERVICE}\` unused by tool \`{tool_name}\`.",
-        ):
-            tool.add_auth_token_getters({AUTH_SERVICE: {}})
-
-    @pytest.mark.asyncio
-    async def test_constructor_getters_missing_fail(self, tool_name, client):
-        """
-        Tests that adding a missing auth token getter raises ValueError.
-        """
-        AUTH_SERVICE = "xmy-auth-service"
-
-        with pytest.raises(
-            ValueError,
-            match=f"Validation failed for tool '{tool_name}': unused auth tokens: {AUTH_SERVICE}.",
-        ):
-            await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
-
-
 class TestBoundParameter:
 
     @pytest.fixture

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -398,6 +398,35 @@ class TestAuth:
             await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
 
 
+    @pytest.mark.asyncio
+    async def test_add_auth_token_getters_missing_fail(self, tool_name, client):
+        """
+        Tests that adding a missing auth token getter raises ValueError.
+        """
+        AUTH_SERVICE = "xmy-auth-service"
+
+        tool = await client.load_tool(tool_name)
+
+        with pytest.raises(
+            ValueError,
+            match=f"Authentication source\(s\) \`{AUTH_SERVICE}\` unused by tool \`{tool_name}\`.",
+        ):
+            tool.add_auth_token_getters({AUTH_SERVICE: {}})
+
+    @pytest.mark.asyncio
+    async def test_constructor_getters_missing_fail(self, tool_name, client):
+        """
+        Tests that adding a missing auth token getter raises ValueError.
+        """
+        AUTH_SERVICE = "xmy-auth-service"
+
+        with pytest.raises(
+            ValueError,
+            match=f"Validation failed for tool '{tool_name}': unused auth tokens: {AUTH_SERVICE}.",
+        ):
+            await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
+
+
 class TestBoundParameter:
 
     @pytest.fixture


### PR DESCRIPTION
Now we do not need to put an `await` while calling `add_headers()` method.

### Before
```py
await client.add_headers({"header": "value"})
```

### After
```py
client.add_headers({"header": "value"})
```