### PR TITLE
fix(toolbox-core)!: Throw PermissionError on unauthenticated tool invocation

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -239,7 +239,7 @@ class ToolboxTool:
             for s in self.__required_authn_params.values():
                 req_auth_services.update(s)
             req_auth_services.update(self.__required_authz_tokens)
-            raise ValueError(
+            raise PermissionError(
                 f"One or more of the following authn services are required to invoke this tool"
                 f": {','.join(req_auth_services)}"
             )

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -257,27 +257,18 @@ class ToolboxTool:
             payload[param] = await resolve_value(value)
 
         # create headers for auth services
-        auth_headers = {}
+        headers = {}
         for auth_service, token_getter in self.__auth_service_token_getters.items():
-            auth_headers[self.__get_auth_header(auth_service)] = await resolve_value(
+            headers[self.__get_auth_header(auth_service)] = await resolve_value(
                 token_getter
             )
         for client_header_name, client_header_val in self.__client_headers.items():
-            auth_headers[client_header_name] = await resolve_value(client_header_val)
-
-        # ID tokens contain sensitive user information (claims). Transmitting
-        # these over HTTP exposes the data to interception and unauthorized
-        # access. Always use HTTPS to ensure secure communication and protect
-        # user privacy.
-        if auth_headers and not self.__url.startswith("https://"):
-            warn(
-                "Sending ID token over HTTP. User data may be exposed. Use HTTPS for secure communication."
-            )
+            headers[client_header_name] = await resolve_value(client_header_val)
 
         async with self.__session.post(
             self.__url,
             json=payload,
-            headers=auth_headers,
+            headers=headers,
         ) as resp:
             body = await resp.json()
             if resp.status < 200 or resp.status >= 300:

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -398,35 +398,6 @@ class TestAuth:
             await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
 
 
-    @pytest.mark.asyncio
-    async def test_add_auth_token_getters_missing_fail(self, tool_name, client):
-        """
-        Tests that adding a missing auth token getter raises ValueError.
-        """
-        AUTH_SERVICE = "xmy-auth-service"
-
-        tool = await client.load_tool(tool_name)
-
-        with pytest.raises(
-            ValueError,
-            match=f"Authentication source\(s\) \`{AUTH_SERVICE}\` unused by tool \`{tool_name}\`.",
-        ):
-            tool.add_auth_token_getters({AUTH_SERVICE: {}})
-
-    @pytest.mark.asyncio
-    async def test_constructor_getters_missing_fail(self, tool_name, client):
-        """
-        Tests that adding a missing auth token getter raises ValueError.
-        """
-        AUTH_SERVICE = "xmy-auth-service"
-
-        with pytest.raises(
-            ValueError,
-            match=f"Validation failed for tool '{tool_name}': unused auth tokens: {AUTH_SERVICE}.",
-        ):
-            await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
-
-
 class TestBoundParameter:
 
     @pytest.fixture

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -398,6 +398,35 @@ class TestAuth:
             await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
 
 
+    @pytest.mark.asyncio
+    async def test_add_auth_token_getters_missing_fail(self, tool_name, client):
+        """
+        Tests that adding a missing auth token getter raises ValueError.
+        """
+        AUTH_SERVICE = "xmy-auth-service"
+
+        tool = await client.load_tool(tool_name)
+
+        with pytest.raises(
+            ValueError,
+            match=f"Authentication source\(s\) \`{AUTH_SERVICE}\` unused by tool \`{tool_name}\`.",
+        ):
+            tool.add_auth_token_getters({AUTH_SERVICE: {}})
+
+    @pytest.mark.asyncio
+    async def test_constructor_getters_missing_fail(self, tool_name, client):
+        """
+        Tests that adding a missing auth token getter raises ValueError.
+        """
+        AUTH_SERVICE = "xmy-auth-service"
+
+        with pytest.raises(
+            ValueError,
+            match=f"Validation failed for tool '{tool_name}': unused auth tokens: {AUTH_SERVICE}.",
+        ):
+            await client.load_tool(tool_name, auth_token_getters={AUTH_SERVICE: {}})
+
+
 class TestBoundParameter:
 
     @pytest.fixture

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -147,7 +147,7 @@ class TestAuth:
         """Tests running a tool requiring auth without providing auth."""
         tool = await toolbox.load_tool("get-row-by-id-auth")
         with pytest.raises(
-            Exception,
+            PermissionError,
             match="One or more of the following authn services are required to invoke this tool: my-test-auth",
         ):
             await tool(id="2")
@@ -188,7 +188,7 @@ class TestAuth:
         """Tests running a tool with a param requiring auth, without auth."""
         tool = await toolbox.load_tool("get-row-by-email-auth")
         with pytest.raises(
-            ValueError,
+            PermissionError,
             match="One or more of the following authn services are required to invoke this tool: my-test-auth",
         ):
             await tool()

--- a/packages/toolbox-core/tests/test_sync_client.py
+++ b/packages/toolbox-core/tests/test_sync_client.py
@@ -541,7 +541,7 @@ class TestSyncAuth:
 
         tool = sync_client.load_tool(tool_name_auth)
         with pytest.raises(
-            ValueError,
+            PermissionError,
             match="One or more of the following authn services are required to invoke this tool: my-auth-service",
         ):
             tool(argA=15, argB=True)

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -129,7 +129,7 @@ class TestAuth:
         """Tests running a tool requiring auth without providing auth."""
         tool = toolbox.load_tool("get-row-by-id-auth")
         with pytest.raises(
-            Exception,
+            PermissionError,
             match="One or more of the following authn services are required to invoke this tool: my-test-auth",
         ):
             tool(id="2")
@@ -156,7 +156,7 @@ class TestAuth:
         """Tests running a tool with a param requiring auth, without auth."""
         tool = toolbox.load_tool("get-row-by-email-auth")
         with pytest.raises(
-            ValueError,
+            PermissionError,
             match="One or more of the following authn services are required to invoke this tool: my-test-auth",
         ):
             tool()


### PR DESCRIPTION
Earlier a `ValueError` was being thrown. In case of unauthenticated tool calls, a `PermissionError` is more suitable.