### PR TITLE
feat: Make name optional while loading toolset through sync client

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -108,7 +108,7 @@ class ToolboxSyncClient:
 
     def load_toolset(
         self,
-        name: str,
+        name: Optional[str] = None,
         auth_token_getters: dict[str, Callable[[], str]] = {},
         bound_params: Mapping[str, Union[Callable[[], Any], Any]] = {},
         strict: bool = False,
@@ -117,7 +117,7 @@ class ToolboxSyncClient:
         Synchronously fetches a toolset and loads all tools defined within it.
 
         Args:
-            name: Name of the toolset to load tools.
+            name: Name of the toolset to load. If None, loads the default toolset.
             auth_token_getters: A mapping of authentication service names to
                 callables that return the corresponding authentication token.
             bound_params: A mapping of parameter names to bind to specific values or


### PR DESCRIPTION
This aligns with the async client's `load_toolset` method.