### PR TITLE
chore: Define precedence for deprecated 'auth_tokens' vs. 'auth_headers'

### DIFF
--- a/packages/toolbox-langchain/src/toolbox_langchain/async_client.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_client.py
@@ -68,19 +68,6 @@ class AsyncToolboxClient:
         Returns:
             A tool loaded from the Toolbox.
         """
-        if auth_headers:
-            if auth_token_getters:
-                warn(
-                    "Both `auth_token_getters` and `auth_headers` are provided. `auth_headers` is deprecated, and `auth_token_getters` will be used.",
-                    DeprecationWarning,
-                )
-            else:
-                warn(
-                    "Argument `auth_headers` is deprecated. Use `auth_token_getters` instead.",
-                    DeprecationWarning,
-                )
-                auth_token_getters = auth_headers
-
         if auth_tokens:
             if auth_token_getters:
                 warn(
@@ -93,6 +80,19 @@ class AsyncToolboxClient:
                     DeprecationWarning,
                 )
                 auth_token_getters = auth_tokens
+
+        if auth_headers:
+            if auth_token_getters:
+                warn(
+                    "Both `auth_token_getters` and `auth_headers` are provided. `auth_headers` is deprecated, and `auth_token_getters` will be used.",
+                    DeprecationWarning,
+                )
+            else:
+                warn(
+                    "Argument `auth_headers` is deprecated. Use `auth_token_getters` instead.",
+                    DeprecationWarning,
+                )
+                auth_token_getters = auth_headers
 
         url = f"{self.__url}/api/tool/{tool_name}"
         manifest: ManifestSchema = await _load_manifest(url, self.__session)
@@ -136,19 +136,6 @@ class AsyncToolboxClient:
         Returns:
             A list of all tools loaded from the Toolbox.
         """
-        if auth_headers:
-            if auth_token_getters:
-                warn(
-                    "Both `auth_token_getters` and `auth_headers` are provided. `auth_headers` is deprecated, and `auth_token_getters` will be used.",
-                    DeprecationWarning,
-                )
-            else:
-                warn(
-                    "Argument `auth_headers` is deprecated. Use `auth_token_getters` instead.",
-                    DeprecationWarning,
-                )
-                auth_token_getters = auth_headers
-
         if auth_tokens:
             if auth_token_getters:
                 warn(
@@ -161,6 +148,19 @@ class AsyncToolboxClient:
                     DeprecationWarning,
                 )
                 auth_token_getters = auth_tokens
+
+        if auth_headers:
+            if auth_token_getters:
+                warn(
+                    "Both `auth_token_getters` and `auth_headers` are provided. `auth_headers` is deprecated, and `auth_token_getters` will be used.",
+                    DeprecationWarning,
+                )
+            else:
+                warn(
+                    "Argument `auth_headers` is deprecated. Use `auth_token_getters` instead.",
+                    DeprecationWarning,
+                )
+                auth_token_getters = auth_headers
 
         url = f"{self.__url}/api/toolset/{toolset_name or ''}"
         manifest: ManifestSchema = await _load_manifest(url, self.__session)


### PR DESCRIPTION
This PR addresses the scenario where a user provides both `auth_tokens` and `auth_headers`, both of which are deprecated arguments.

### Problem
Previously, if a user provided both `auth_tokens` and `auth_headers`, the authentication tokens from `auth_headers` were prioritized. This created an inconsistent behavior, especially considering that `auth_tokens` was deprecated more recently than `auth_headers`.

### Solution
This change shifts the precedence to `auth_tokens`. Now, if both `auth_tokens` and `auth_headers` are present, only the authentication tokens specified in `auth_tokens` will be considered.

### Reasoning
1.  `auth_tokens` was deprecated more recently than `auth_headers`. Prioritizing the more recently deprecated argument provides a clearer signal to users about the intended deprecation path and guides them towards the recommended, non-deprecated args.
2.  We opted *not* to merge authentication tokens from both deprecated arguments. Merging could lead to increased user confusion and inadvertently encourage continued reliance on these legacy features, hindering migration efforts.
3.  This approach aligns with our broader deprecation strategy. For instance, when a user provides `auth_token_getters` (the current recommended approach) alongside a deprecated argument like `auth_tokens`, `auth_token_getters` takes precedence and overrides the deprecated argument. This PR extends that "latest argument wins" principle to the deprecated arguments themselves, ensuring consistent behavior.