### PR TITLE
chore(toolbox-langchain): Pin toolbox-core version

### DIFF
--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -9,8 +9,8 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    # TODO: Bump lowest supported version to 0.2.0
-    "toolbox-core>=0.1.0,<1.0.0",
+    # TODO: Bump toolbox-core version to 0.2.0
+    "toolbox-core==0.1.0",
     "langchain-core>=0.2.23,<1.0.0",
     "PyYAML>=6.0.1,<7.0.0",
     "pydantic>=2.7.0,<3.0.0",


### PR DESCRIPTION
We would tie up the versions of orchestration specific packages (`toolbox-langchain` in this case), so that they are always equal.