### PR TITLE
chore: Improve type hints for async `bound_params`, `auth_token_getters`, and `client_headers`

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -15,7 +15,7 @@
 
 import asyncio
 from threading import Thread
-from typing import Any, Callable, Coroutine, Mapping, Optional, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Union
 
 from .client import ToolboxClient
 from .sync_tool import ToolboxSyncTool
@@ -35,7 +35,9 @@ class ToolboxSyncClient:
     def __init__(
         self,
         url: str,
-        client_headers: Optional[Mapping[str, Union[Callable, Coroutine, str]]] = None,
+        client_headers: Optional[
+            Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
+        ] = None,
     ):
         """
         Initializes the ToolboxSyncClient.
@@ -75,8 +77,12 @@ class ToolboxSyncClient:
     def load_tool(
         self,
         name: str,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: Mapping[str, Union[Callable[[], Any], Any]] = {},
+        auth_token_getters: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]]]
+        ] = {},
+        bound_params: Mapping[
+            str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]
+        ] = {},
     ) -> ToolboxSyncTool:
         """
         Synchronously loads a tool from the server.
@@ -108,8 +114,12 @@ class ToolboxSyncClient:
     def load_toolset(
         self,
         name: Optional[str] = None,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: Mapping[str, Union[Callable[[], Any], Any]] = {},
+        auth_token_getters: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]]]
+        ] = {},
+        bound_params: Mapping[
+            str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]
+        ] = {},
         strict: bool = False,
     ) -> list[ToolboxSyncTool]:
         """
@@ -148,7 +158,10 @@ class ToolboxSyncClient:
         ]
 
     def add_headers(
-        self, headers: Mapping[str, Union[Callable, Coroutine, str]]
+        self,
+        headers: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]
+        ],
     ) -> None:
         """
         Add headers to be included in each request sent through this client.

--- a/packages/toolbox-core/src/toolbox_core/sync_tool.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_tool.py
@@ -17,7 +17,7 @@ import asyncio
 from asyncio import AbstractEventLoop
 from inspect import Signature
 from threading import Thread
-from typing import Any, Callable, Coroutine, Mapping, Sequence, Union
+from typing import Any, Awaitable, Callable, Mapping, Sequence, Union
 
 from .protocol import ParameterSchema
 from .tool import ToolboxTool
@@ -102,7 +102,9 @@ class ToolboxSyncTool:
         return self.__async_tool._params
 
     @property
-    def _bound_params(self) -> Mapping[str, Union[Callable[[], Any], Any]]:
+    def _bound_params(
+        self,
+    ) -> Mapping[str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]]:
         return self.__async_tool._bound_params
 
     @property
@@ -110,11 +112,15 @@ class ToolboxSyncTool:
         return self.__async_tool._required_auth_params
 
     @property
-    def _auth_service_token_getters(self) -> Mapping[str, Callable[[], str]]:
+    def _auth_service_token_getters(
+        self,
+    ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]]]]:
         return self.__async_tool._auth_service_token_getters
 
     @property
-    def _client_headers(self) -> Mapping[str, Union[Callable, Coroutine, str]]:
+    def _client_headers(
+        self,
+    ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]:
         return self.__async_tool._client_headers
 
     def __call__(self, *args: Any, **kwargs: Any) -> str:
@@ -136,7 +142,9 @@ class ToolboxSyncTool:
 
     def add_auth_token_getters(
         self,
-        auth_token_getters: Mapping[str, Callable[[], str]],
+        auth_token_getters: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]]]
+        ],
     ) -> "ToolboxSyncTool":
         """
         Registers auth token getter functions that are used for AuthServices
@@ -159,7 +167,9 @@ class ToolboxSyncTool:
         return ToolboxSyncTool(new_async_tool, self.__loop, self.__thread)
 
     def add_auth_token_getter(
-        self, auth_source: str, get_id_token: Callable[[], str]
+        self,
+        auth_source: str,
+        get_id_token: Union[Callable[[], str], Callable[[], Awaitable[str]]],
     ) -> "ToolboxSyncTool":
         """
         Registers an auth token getter function that is used for AuthService
@@ -181,7 +191,10 @@ class ToolboxSyncTool:
         return self.add_auth_token_getters({auth_source: get_id_token})
 
     def bind_params(
-        self, bound_params: Mapping[str, Union[Callable[[], Any], Any]]
+        self,
+        bound_params: Mapping[
+            str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]
+        ],
     ) -> "ToolboxSyncTool":
         """
         Binds parameters to values or callables that produce values.
@@ -204,7 +217,7 @@ class ToolboxSyncTool:
     def bind_param(
         self,
         param_name: str,
-        param_value: Union[Callable[[], Any], Any],
+        param_value: Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any],
     ) -> "ToolboxSyncTool":
         """
         Binds a parameter to the value or callable that produce the value.

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -15,7 +15,7 @@
 import copy
 from inspect import Signature
 from types import MappingProxyType
-from typing import Any, Callable, Coroutine, Mapping, Optional, Sequence, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 from warnings import warn
 
 from aiohttp import ClientSession
@@ -51,9 +51,15 @@ class ToolboxTool:
         params: Sequence[ParameterSchema],
         required_authn_params: Mapping[str, list[str]],
         required_authz_tokens: Sequence[str],
-        auth_service_token_getters: Mapping[str, Callable[[], str]],
-        bound_params: Mapping[str, Union[Callable[[], Any], Any]],
-        client_headers: Mapping[str, Union[Callable, Coroutine, str]],
+        auth_service_token_getters: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]]]
+        ],
+        bound_params: Mapping[
+            str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]
+        ],
+        client_headers: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]
+        ],
     ):
         """
         Initializes a callable that will trigger the tool invocation through the
@@ -143,7 +149,9 @@ class ToolboxTool:
         return copy.deepcopy(self.__params)
 
     @property
-    def _bound_params(self) -> Mapping[str, Union[Callable[[], Any], Any]]:
+    def _bound_params(
+        self,
+    ) -> Mapping[str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]]:
         return MappingProxyType(self.__bound_parameters)
 
     @property
@@ -151,11 +159,15 @@ class ToolboxTool:
         return MappingProxyType(self.__required_authn_params)
 
     @property
-    def _auth_service_token_getters(self) -> Mapping[str, Callable[[], str]]:
+    def _auth_service_token_getters(
+        self,
+    ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]]]]:
         return MappingProxyType(self.__auth_service_token_getters)
 
     @property
-    def _client_headers(self) -> Mapping[str, Union[Callable, Coroutine, str]]:
+    def _client_headers(
+        self,
+    ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]:
         return MappingProxyType(self.__client_headers)
 
     def __copy(
@@ -167,9 +179,15 @@ class ToolboxTool:
         params: Optional[Sequence[ParameterSchema]] = None,
         required_authn_params: Optional[Mapping[str, list[str]]] = None,
         required_authz_tokens: Optional[Sequence[str]] = None,
-        auth_service_token_getters: Optional[Mapping[str, Callable[[], str]]] = None,
-        bound_params: Optional[Mapping[str, Union[Callable[[], Any], Any]]] = None,
-        client_headers: Optional[Mapping[str, Union[Callable, Coroutine, str]]] = None,
+        auth_service_token_getters: Optional[
+            Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]]]]
+        ] = None,
+        bound_params: Optional[
+            Mapping[str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]]
+        ] = None,
+        client_headers: Optional[
+            Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
+        ] = None,
     ) -> "ToolboxTool":
         """
         Creates a copy of the ToolboxTool, overriding specific fields.
@@ -278,7 +296,9 @@ class ToolboxTool:
 
     def add_auth_token_getters(
         self,
-        auth_token_getters: Mapping[str, Callable[[], str]],
+        auth_token_getters: Mapping[
+            str, Union[Callable[[], str], Callable[[], Awaitable[str]]]
+        ],
     ) -> "ToolboxTool":
         """
         Registers auth token getter functions that are used for AuthServices
@@ -347,7 +367,9 @@ class ToolboxTool:
         )
 
     def add_auth_token_getter(
-        self, auth_source: str, get_id_token: Callable[[], str]
+        self,
+        auth_source: str,
+        get_id_token: Union[Callable[[], str], Callable[[], Awaitable[str]]],
     ) -> "ToolboxTool":
         """
         Registers an auth token getter function that is used for AuthService
@@ -369,7 +391,10 @@ class ToolboxTool:
         return self.add_auth_token_getters({auth_source: get_id_token})
 
     def bind_params(
-        self, bound_params: Mapping[str, Union[Callable[[], Any], Any]]
+        self,
+        bound_params: Mapping[
+            str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]
+        ],
     ) -> "ToolboxTool":
         """
         Binds parameters to values or callables that produce values.
@@ -413,7 +438,7 @@ class ToolboxTool:
     def bind_param(
         self,
         param_name: str,
-        param_value: Union[Callable[[], Any], Any],
+        param_value: Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any],
     ) -> "ToolboxTool":
         """
         Binds a parameter to the value or callable that produce the value.

--- a/packages/toolbox-core/src/toolbox_core/utils.py
+++ b/packages/toolbox-core/src/toolbox_core/utils.py
@@ -122,7 +122,7 @@ def params_to_pydantic_model(
 
 
 async def resolve_value(
-    source: Union[Callable[[], Awaitable[Any]], Callable[[], Any], Any],
+    source: Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any],
 ) -> Any:
     """
     Asynchronously or synchronously resolves a given source to its value.


### PR DESCRIPTION
This PR enhances the type hints for `bound_params`, `auth_token_getters`, and `client_headers` arguments in the APIs of both tool and client classes.

Previously, these type hints incorrectly suggested that these callables could only be synchronous functions, or in some cases, specifically `Coroutine` objects:
* `auth_token_getters`: Expected `Callable[[], str]`
* `bound_params`: Expected `Callable[[], Any]`
* `client_headers`: `Coroutine`

This was inaccurate as these can also be asynchronous (`async def`) functions.

This PR corrects the type hints to accurately reflect that these callables can be either synchronous or asynchronous:
* **`auth_token_getter`**: Now accepts `Callable[[], str]` or `Callable[[], Awaitable[str]]`.
* **`bound_params`**: Now accepts `Callable[[], Any]` or `Callable[[], Awaitable[Any]]`.
* **`client_headers`**: Now accepts `Callable[[], Any]` or `Callable[[], Awaitable[str]]`.

This ensures type checkers correctly validate both synchronous and asynchronous implementations for these parameters.

This PR also improves accuracy for `auth_token_getter` signatures to be more abstract parameter types:
    * **Previously:** For `auth_token_getter` callables that accepted `dict` arguments in their own signature.
    * **Now:** These have been updated to use `typing.Mapping`. This is more accurate as it allows for any object implementing the mapping protocol (not just `dict` instances), offering greater flexibility.