### PR TITLE
chore: Align `toolbox-core` dependency for synchronized releases

### DIFF
--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -9,8 +9,7 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    # TODO: Bump toolbox-core version to 0.2.0
-    "toolbox-core==0.1.0",
+    "toolbox-core==0.1.0",              # x-release-please-version
     "langchain-core>=0.2.23,<1.0.0",
     "PyYAML>=6.0.1,<7.0.0",
     "pydantic>=2.7.0,<3.0.0",

--- a/packages/toolbox-llamaindex/pyproject.toml
+++ b/packages/toolbox-llamaindex/pyproject.toml
@@ -9,8 +9,7 @@ authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
 dependencies = [
-    # TODO: Bump toolbox-core version to 0.2.0
-    "toolbox-core==0.1.0",
+    "toolbox-core==0.1.0",              # x-release-please-version
     "llama-index>=0.12.0,<1.0.0",
     "PyYAML>=6.0.1,<7.0.0",
     "pydantic>=2.8.0,<3.0.0",


### PR DESCRIPTION
To ensure `toolbox-core`, `toolbox-langchain`, and `toolbox-llamaindex` are always released together with the exact same version, this PR pins the `toolbox-core` dependency in the `pyproject.toml` files of `toolbox-langchain` and `toolbox-llamaindex` to match their own versions.

This allows `release-please` to automatically update this pinned dependency when bumping package versions.

> [!NOTE]
> This change does not affect `requirements.txt` files, as they handle local editable installs of `toolbox-core` which do not require explicit versioning.