### PR TITLE
fix(toolbox-core): Prevent `ToolboxClient` from closing externally managed client sessions

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -28,7 +28,8 @@ class ToolboxClient:
     An asynchronous client for interacting with a Toolbox service.
 
     Provides methods to discover and load tools defined by a remote Toolbox
-    service endpoint. It manages an underlying `aiohttp.ClientSession`.
+    service endpoint. It manages an underlying `aiohttp.ClientSession`, if one
+    is not provided.
     """
 
     __base_url: str

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -145,8 +145,7 @@ class ToolboxClient:
         any tools created by this Client to cease to function.
 
         If the session was provided externally during initialization, the caller
-        is responsible for its lifecycle, but calling close here will still
-        attempt to close it.
+        is responsible for its lifecycle.
         """
         if self.__manage_session:
             await self.__session.close()

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -33,6 +33,7 @@ class ToolboxClient:
 
     __base_url: str
     __session: ClientSession
+    __manage_session: bool
 
     def __init__(
         self,
@@ -56,7 +57,9 @@ class ToolboxClient:
         self.__base_url = url
 
         # If no aiohttp.ClientSession is provided, make our own
+        self.__manage_session = False
         if session is None:
+            self.__manage_session = True
             session = ClientSession()
         self.__session = session
 
@@ -145,7 +148,8 @@ class ToolboxClient:
         is responsible for its lifecycle, but calling close here will still
         attempt to close it.
         """
-        await self.__session.close()
+        if self.__manage_session:
+            await self.__session.close()
 
     async def load_tool(
         self,

--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -66,10 +66,6 @@ class ToolboxSyncClient:
         """
         Synchronously closes the underlying client session. Doing so will cause
         any tools created by this Client to cease to function.
-
-        If the session was provided externally during initialization, the caller
-        is responsible for its lifecycle, but calling close here will still
-        attempt to close it.
         """
         coro = self.__async_client.close()
         asyncio.run_coroutine_threadsafe(coro, self.__loop).result()

--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -68,7 +68,7 @@ class ToolboxSyncClient:
         any tools created by this Client to cease to function.
         """
         coro = self.__async_client.close()
-        run_coroutine_threadsafe(coro, self.__loop).result()
+        run_coroutine_threadsafe(coro, self.__loop).result(timeout=5)
 
     def __del__(self):
         self.close()

--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -67,9 +67,8 @@ class ToolboxSyncClient:
         Synchronously closes the underlying client session. Doing so will cause
         any tools created by this Client to cease to function.
         """
-        if not self.__async_client.__session.closed:
-            coro = self.__async_client.close()
-            run_coroutine_threadsafe(coro, self.__loop).result()
+        coro = self.__async_client.close()
+        run_coroutine_threadsafe(coro, self.__loop).result()
 
     def __del__(self):
         self.close()

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -22,12 +22,15 @@ import platform
 import subprocess
 import tempfile
 import time
+from asyncio import run_coroutine_threadsafe
 from typing import Generator
 
 import google
 import pytest_asyncio
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
+
+from toolbox_core import ToolboxSyncClient
 
 
 #### Define Utility Functions
@@ -92,6 +95,38 @@ def get_auth_token(client_id: str) -> str:
 
 
 #### Define Fixtures
+@pytest_asyncio.fixture(autouse=True)
+def patch_sync_client_for_deadlock(monkeypatch):
+    """
+    Automatically replaces the blocking `ToolboxSyncClient.close()` method
+    with a non-blocking version for the entire test run.
+
+    The original `ToolboxSyncClient.close()` is a blocking method because it
+    calls `.result()`. In the pytest environment, this blocking call creates a
+    deadlock during the test teardown phase when it conflicts with other fixtures
+    (like `sync_client_environment` or `toolbox_server`) that are also managing
+    background processes and threads.
+
+    By replacing `close` with this safe, non-blocking version, we prevent the
+    deadlock and allow the test suite's fixtures to tear down cleanly.
+    This change is only active during the test run.
+    """
+
+    def non_blocking_close(self):
+        """A replacement for close() that doesn't block."""
+        if hasattr(self.__class__, "_ToolboxSyncClient__loop") and hasattr(
+            self, "_ToolboxSyncClient__async_client"
+        ):
+            loop = self.__class__._ToolboxSyncClient__loop
+            async_client = self._ToolboxSyncClient__async_client
+
+            if loop and loop.is_running():
+                coro = async_client.close()
+                run_coroutine_threadsafe(coro, loop)
+
+    monkeypatch.setattr(ToolboxSyncClient, "close", non_blocking_close)
+
+
 @pytest_asyncio.fixture(scope="session")
 def project_id() -> str:
     return get_env_var("GOOGLE_CLOUD_PROJECT")

--- a/packages/toolbox-core/tests/test_sync_client.py
+++ b/packages/toolbox-core/tests/test_sync_client.py
@@ -47,7 +47,7 @@ def sync_client_environment():
     if original_loop and original_loop.is_running():
         original_loop.call_soon_threadsafe(original_loop.stop)
         if original_thread and original_thread.is_alive():
-            original_thread.join(timeout=5)
+            original_thread.join()
         ToolboxSyncClient._ToolboxSyncClient__loop = None
         ToolboxSyncClient._ToolboxSyncClient__thread = None
 
@@ -63,7 +63,7 @@ def sync_client_environment():
     if test_loop and test_loop.is_running():
         test_loop.call_soon_threadsafe(test_loop.stop)
     if test_thread and test_thread.is_alive():
-        test_thread.join(timeout=5)
+        test_thread.join()
 
     # Explicitly set to None to ensure a clean state for the next fixture use/test.
     ToolboxSyncClient._ToolboxSyncClient__loop = None

--- a/packages/toolbox-core/tests/test_sync_client.py
+++ b/packages/toolbox-core/tests/test_sync_client.py
@@ -14,7 +14,6 @@
 
 
 import inspect
-from asyncio import run_coroutine_threadsafe
 from typing import Any, Callable, Mapping, Optional
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -27,31 +26,6 @@ from toolbox_core.sync_client import ToolboxSyncClient
 from toolbox_core.sync_tool import ToolboxSyncTool
 
 TEST_BASE_URL = "http://toolbox.example.com"
-
-
-# The original `ToolboxSyncClient.close()` is a blocking method because it
-# calls `.result()`. In the pytest environment, this blocking call creates a
-# deadlock during the test teardown phase when it conflicts with the
-# `sync_client_environment` fixture that also manages the background thread.
-#
-# By replacing `close` with our non-blocking version for the test run,
-# we prevent this deadlock and allow the test suite to tear down cleanly.
-@pytest.fixture(autouse=True)
-def patch_sync_client_for_deadlock(monkeypatch):
-    """
-    Automatically replaces the blocking `ToolboxSyncClient.close()` method
-    with a non-blocking version for the entire test run.
-    """
-
-    def non_blocking_close(self):
-        """A replacement for close() that doesn't block."""
-        loop = self.__class__._ToolboxSyncClient__loop
-        async_client = self._ToolboxSyncClient__async_client
-
-        coro = async_client.close()
-        run_coroutine_threadsafe(coro, loop)
-
-    monkeypatch.setattr(ToolboxSyncClient, "close", non_blocking_close)
 
 
 @pytest.fixture

--- a/packages/toolbox-core/tests/test_sync_client.py
+++ b/packages/toolbox-core/tests/test_sync_client.py
@@ -14,9 +14,9 @@
 
 
 import inspect
+from asyncio import run_coroutine_threadsafe
 from typing import Any, Callable, Mapping, Optional
 from unittest.mock import AsyncMock, Mock, patch
-from asyncio import run_coroutine_threadsafe
 
 import pytest
 from aioresponses import CallbackResult, aioresponses
@@ -28,13 +28,14 @@ from toolbox_core.sync_tool import ToolboxSyncTool
 
 TEST_BASE_URL = "http://toolbox.example.com"
 
-    # The original `ToolboxSyncClient.close()` is a blocking method because it
-    # calls `.result()`. In the pytest environment, this blocking call creates a
-    # deadlock during the test teardown phase when it conflicts with the
-    # `sync_client_environment` fixture that also manages the background thread.
-    #
-    # By replacing `close` with our non-blocking version for the test run,
-    # we prevent this deadlock and allow the test suite to tear down cleanly.
+
+# The original `ToolboxSyncClient.close()` is a blocking method because it
+# calls `.result()`. In the pytest environment, this blocking call creates a
+# deadlock during the test teardown phase when it conflicts with the
+# `sync_client_environment` fixture that also manages the background thread.
+#
+# By replacing `close` with our non-blocking version for the test run,
+# we prevent this deadlock and allow the test suite to tear down cleanly.
 @pytest.fixture(autouse=True)
 def patch_sync_client_for_deadlock(monkeypatch):
     """
@@ -51,6 +52,7 @@ def patch_sync_client_for_deadlock(monkeypatch):
         run_coroutine_threadsafe(coro, loop)
 
     monkeypatch.setattr(ToolboxSyncClient, "close", non_blocking_close)
+
 
 @pytest.fixture
 def sync_client_environment():

--- a/packages/toolbox-langchain/src/toolbox_langchain/client.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/client.py
@@ -17,7 +17,6 @@ from typing import Any, Callable, Optional, Union
 from warnings import warn
 
 from toolbox_core.sync_client import ToolboxSyncClient as ToolboxCoreSyncClient
-from toolbox_core.sync_tool import ToolboxSyncTool
 
 from .tools import ToolboxTool
 


### PR DESCRIPTION
Fixes #208 

This change ensures that the `ToolboxClient` only closes client sessions that it creates and manages internally. If a client session is provided externally (i.e., injected into the `ToolboxClient`), the responsibility for managing its lifecycle, including closing it, remains with the entity that provided it. This prevents unintended closure of externally managed sessions.