### PR TITLE
ci: release-please to tag pull request number

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -14,3 +14,4 @@
 
 handleGHRelease: true
 manifest: true
+tagPullRequestNumber: true


### PR DESCRIPTION
This repository creates multiple Git tags upon one release pull request. Example: https://github.com/googleapis/mcp-toolbox-sdk-python/commit/ca9ff141a08cf447e5ea3d63b8f2d36e1aa31b6d

To adopt the new release pipeline based on Git tags, this `tagPullRequestNumber` creates an additional `release-please-<pr number>` tag to a release. We'll monitor that tag to trigger one release job for one release. This option has been working good for google-cloud-go ([example](https://github.com/googleapis/google-cloud-go/commit/8332a9bdf43cd7bbf0256057e48ee49b2a7f1144)).

b/415834227