### PR TITLE
docs: Improve API error handling for `toolbox-core` client

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -193,6 +193,11 @@ class ToolboxClient:
         # request the definition of the tool from the server
         url = f"{self.__base_url}/api/tool/{name}"
         async with self.__session.get(url, headers=resolved_headers) as response:
+            if not response.ok:
+                error_text = await response.text()
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). Server response: {error_text}"
+                )
             json = await response.json()
         manifest: ManifestSchema = ManifestSchema(**json)
 

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -271,7 +271,7 @@ class ToolboxClient:
         # Request the definition of the toolset from the server
         url = f"{self.__base_url}/api/toolset/{name or ''}"
         async with self.__session.get(url, headers=resolved_headers) as response:
-            if response.status != 200:
+            if not response.ok:
                 error_text = await response.text()
                 raise RuntimeError(
                     f"API request failed with status {response.status} ({response.reason}). Server response: {error_text}"

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from asyncio import get_running_loop
 from types import MappingProxyType
 from typing import Any, Awaitable, Callable, Mapping, Optional, Union
 
@@ -272,6 +271,11 @@ class ToolboxClient:
         # Request the definition of the toolset from the server
         url = f"{self.__base_url}/api/toolset/{name or ''}"
         async with self.__session.get(url, headers=resolved_headers) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). Server response: {error_text}"
+                )
             json = await response.json()
         manifest: ManifestSchema = ManifestSchema(**json)
 

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -289,7 +289,7 @@ class ToolboxTool:
             headers=headers,
         ) as resp:
             body = await resp.json()
-            if resp.status < 200 or resp.status >= 300:
+            if not resp.ok:
                 err = body.get("error", f"unexpected status from server: {resp.status}")
                 raise Exception(err)
         return body.get("result", body)


### PR DESCRIPTION
Fixes #273 

## Problem
Currently, the SDK client unconditionally attempts to parse all API responses as JSON. If the remote server returns an error (e.g., 403 Forbidden due to an authentication failure, or 404 Not Found), the response body is often HTML or plain text, not JSON.

This leads to a low-level `ContentTypeError`, which masks the original, more informative error from the server (like the HTTP status and reason). Users are left with a confusing `"response not parseable"` message instead of knowing the true cause of the failure.

## Solution
This PR introduces a check to validate the HTTP response status before attempting to parse its body.

If the response status is not 200 OK, the client now captures the status code, reason phrase, and the raw response body.
It then raises a `RuntimeError` that includes all of this valuable context.
This ensures that the actual error from the server is always surfaced to the user.

## Before
```
aiohttp.client_exceptions.ContentTypeError: 403, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8'
```
## After
```
RuntimeError: API request failed with status 403 (Forbidden). Server response: Forbidden
```