### PR TITLE
feat(toolbox-langchain): Support per-invocation auth via `RunnableConfig`

### DIFF
--- a/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
@@ -81,13 +81,13 @@ class AsyncToolboxTool(BaseTool):
                 # getters are used by the tool. To prevent validation errors,
                 # filter the incoming getters to include only those that this
                 # specific tool requires.
-                required_auth_keys = set(self.__core_tool._required_authz_tokens)
+                req_auth_services = set(self.__core_tool._required_authz_tokens)
                 for auth_list in self.__core_tool._required_authn_params.values():
-                    required_auth_keys.update(auth_list)
+                    req_auth_services.update(auth_list)
                 filtered_getters = {
                     k: v
                     for k, v in auth_token_getters.items()
-                    if k in required_auth_keys
+                    if k in req_auth_services
                 }
                 if filtered_getters:
                     tool_to_run = self.__core_tool.add_auth_token_getters(

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from asyncio import to_thread
-from typing import Any, Awaitable, Callable, Mapping, Sequence, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 
 from deprecated import deprecated
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 from toolbox_core.sync_tool import ToolboxSyncTool as ToolboxCoreSyncTool
 from toolbox_core.utils import params_to_pydantic_model
@@ -73,11 +74,67 @@ class ToolboxTool(BaseTool):
     ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]:
         return self.__core_tool._client_headers
 
-    def _run(self, **kwargs: Any) -> str:
-        return self.__core_tool(**kwargs)
+    def _run(
+        self,
+        config: RunnableConfig,
+        **kwargs: Any,
+    ) -> str:
+        tool_to_run = self.__core_tool
+        if (
+            config
+            and "configurable" in config
+            and "auth_token_getters" in config["configurable"]
+        ):
+            auth_token_getters = config["configurable"]["auth_token_getters"]
+            if auth_token_getters:
 
-    async def _arun(self, **kwargs: Any) -> str:
-        return await to_thread(self.__core_tool, **kwargs)
+                # The `add_auth_token_getters` method requires that all provided
+                # getters are used by the tool. To prevent validation errors,
+                # filter the incoming getters to include only those that this
+                # specific tool requires.
+                required_auth_keys = set(self.__core_tool._required_authz_tokens)
+                for auth_list in self.__core_tool._required_authn_params.values():
+                    required_auth_keys.update(auth_list)
+                filtered_getters = {
+                    k: v
+                    for k, v in auth_token_getters.items()
+                    if k in required_auth_keys
+                }
+                if filtered_getters:
+                    tool_to_run = self.__core_tool.add_auth_token_getters(
+                        filtered_getters
+                    )
+
+        return tool_to_run(**kwargs)
+
+    async def _arun(self, config: RunnableConfig, **kwargs: Any) -> str:
+        tool_to_run = self.__core_tool
+        if (
+            config
+            and "configurable" in config
+            and "auth_token_getters" in config["configurable"]
+        ):
+            auth_token_getters = config["configurable"]["auth_token_getters"]
+            if auth_token_getters:
+
+                # The `add_auth_token_getters` method requires that all provided
+                # getters are used by the tool. To prevent validation errors,
+                # filter the incoming getters to include only those that this
+                # specific tool requires.
+                required_auth_keys = set(self.__core_tool._required_authz_tokens)
+                for auth_list in self.__core_tool._required_authn_params.values():
+                    required_auth_keys.update(auth_list)
+                filtered_getters = {
+                    k: v
+                    for k, v in auth_token_getters.items()
+                    if k in required_auth_keys
+                }
+                if filtered_getters:
+                    tool_to_run = self.__core_tool.add_auth_token_getters(
+                        filtered_getters
+                    )
+
+        return await to_thread(tool_to_run, **kwargs)
 
     def add_auth_token_getters(
         self, auth_token_getters: dict[str, Callable[[], str]]

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -88,13 +88,13 @@ class ToolboxTool(BaseTool):
                 # getters are used by the tool. To prevent validation errors,
                 # filter the incoming getters to include only those that this
                 # specific tool requires.
-                required_auth_keys = set(self.__core_tool._required_authz_tokens)
+                req_auth_services = set(self.__core_tool._required_authz_tokens)
                 for auth_list in self.__core_tool._required_authn_params.values():
-                    required_auth_keys.update(auth_list)
+                    req_auth_services.update(auth_list)
                 filtered_getters = {
                     k: v
                     for k, v in auth_token_getters.items()
-                    if k in required_auth_keys
+                    if k in req_auth_services
                 }
                 if filtered_getters:
                     tool_to_run = self.__core_tool.add_auth_token_getters(

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -286,7 +286,7 @@ class TestToolboxTool:
         expected_result = "sync_run_output"
         mock_core_tool.return_value = expected_result
 
-        result = toolbox_tool._run(**kwargs_to_run)
+        result = toolbox_tool._run(**kwargs_to_run, config={})
 
         assert result == expected_result
         assert mock_core_tool.call_count == 1
@@ -307,7 +307,7 @@ class TestToolboxTool:
 
         mock_to_thread_in_tools.side_effect = to_thread_side_effect
 
-        result = await toolbox_tool._arun(**kwargs_to_run)
+        result = await toolbox_tool._arun(**kwargs_to_run, config={})
 
         assert result == expected_result
         mock_to_thread_in_tools.assert_awaited_once_with(


### PR DESCRIPTION
## Summary
This PR introduces a major enhancement to the `toolbox-langchain` package by adding support for dynamic, per-invocation authentication. This is achieved by reading `auth_token_getters` from LangChain's standard `RunnableConfig`, enabling `ToolboxTool` to be used safely and effectively in multi-user environments like LangGraph.

## Motivation
Currently, authentication tokens can only be provided to a `ToolboxTool` at initialization time, either via `ToolboxClient.load_tool/load_toolset` or by calling `tool.add_auth_token_getters()` on the tool instance. This static binding of credentials poses a significant challenge in modern agentic frameworks like LangGraph.

## Challenge
In LangGraph, a single graph containing tool instances is often created once and then shared across multiple users and requests. It is insecure and impractical to configure these shared tool instances with any single user's credentials. The required credentials must be provided dynamically, on a per-request basis.

## Proposed Solution
This PR solves this problem by introducing a third, invocation-time method for providing auth. It leverages LangChain's idiomatic `RunnableConfig` as the vehicle for passing request-specific authentication, making `toolbox-langchain` fully compatible with multi-tenant and shared-use patterns.

## Description of Changes
The core of this change lies in how the `ToolboxTool` handles an invocation:

* The tool's invocation method (`_arun`/`_run`) is updated to accept the `config: RunnableConfig` argument, which is standard in the LangChain.
* The tool inspects the config for a specific key: `config["configurable"]["auth_token_getters"]`.
* If `auth_token_getters` are found in the config, the tool:
  a. Introspects its own authentication and authorization requirements (using the properties exposed in #294).
  b. Creates a temporary, in-memory copy of the underlying proxied `ToolboxTool`. This is critical, as it ensures the original shared tool instance is never mutated.
* The `auth_token_getters` from the `config` are applied to this new, temporary copy of the tool using its `add_auth_token_getters` method.
* The actual tool execution is performed using this temporary, request-specific authenticated tool instance.

This mechanism provides a thread-safe and secure way to handle user-specific credentials without affecting the shared state of the primary tool in the graph.

## Usage Example
```py
from langchain_core.runnables import RunnableConfig

# Define the per-invocation configuration with the user's token getter
config = RunnableConfig(
    configurable={
        "auth_token_getters": {
            "my-google-auth": lambda: "<TOKEN>"
        }
    }
)

...

result = await agent_executor.ainvoke(
    {"input": "Search for rows by my user ID"},
    config=config
)
```