### PR TITLE
fix(toolbox-langchain): Expose auth requirements from underlying core tool

### DIFF
--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from asyncio import to_thread
-from typing import Any, Callable, Union, Mapping, Sequence, Awaitable
+from typing import Any, Awaitable, Callable, Mapping, Sequence, Union
 
 from deprecated import deprecated
 from langchain_core.tools import BaseTool

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from asyncio import to_thread
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, Mapping, Sequence, Awaitable
 
 from deprecated import deprecated
 from langchain_core.tools import BaseTool
@@ -46,6 +46,32 @@ class ToolboxTool(BaseTool):
             args_schema=params_to_pydantic_model(core_tool._name, core_tool._params),
         )
         self.__core_tool = core_tool
+
+    @property
+    def _bound_params(
+        self,
+    ) -> Mapping[str, Union[Callable[[], Any], Callable[[], Awaitable[Any]], Any]]:
+        return self.__core_tool._bound_params
+
+    @property
+    def _required_authn_params(self) -> Mapping[str, list[str]]:
+        return self.__core_tool._required_authn_params
+
+    @property
+    def _required_authz_tokens(self) -> Sequence[str]:
+        return self.__core_tool._required_authz_tokens
+
+    @property
+    def _auth_service_token_getters(
+        self,
+    ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]]]]:
+        return self.__core_tool._auth_service_token_getters
+
+    @property
+    def _client_headers(
+        self,
+    ) -> Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]:
+        return self.__core_tool._client_headers
 
     def _run(self, **kwargs: Any) -> str:
         return self.__core_tool(**kwargs)

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -318,19 +318,19 @@ class TestToolboxTool:
         assert mock_core_tool.call_args == call(**kwargs_to_run)
 
     def test_toolbox_tool_properties(self, toolbox_tool, mock_core_tool):
-            """Tests that the properties correctly proxy to the core tool."""
-            assert toolbox_tool._bound_params == mock_core_tool._bound_params
-            assert (
-                toolbox_tool._required_authn_params == mock_core_tool._required_authn_params
-            )
-            assert (
-                toolbox_tool._required_authz_tokens == mock_core_tool._required_authz_tokens
-            )
-            assert (
-                toolbox_tool._auth_service_token_getters
-                == mock_core_tool._auth_service_token_getters
-            )
-            assert toolbox_tool._client_headers == mock_core_tool._client_headers
+        """Tests that the properties correctly proxy to the core tool."""
+        assert toolbox_tool._bound_params == mock_core_tool._bound_params
+        assert (
+            toolbox_tool._required_authn_params == mock_core_tool._required_authn_params
+        )
+        assert (
+            toolbox_tool._required_authz_tokens == mock_core_tool._required_authz_tokens
+        )
+        assert (
+            toolbox_tool._auth_service_token_getters
+            == mock_core_tool._auth_service_token_getters
+        )
+        assert toolbox_tool._client_headers == mock_core_tool._client_headers
 
     def test_toolbox_tool_add_auth_tokens_deprecated(
         self, auth_toolbox_tool, mock_core_sync_auth_tool


### PR DESCRIPTION
This PR exposes the authentication and authorization requirements from the underlying `toolbox-core`'s `ToolboxTool` as properties on the `toolbox-langchain`'s `ToolboxTool` wrapper.

This change forwards the properties introduced in #294, making them accessible at the LangChain integration layer. It is a key prerequisite for implementing self-authenticating tools (#291), as it allows higher-level abstractions to inspect a tool's auth needs directly.