### PR TITLE
docs(toolbox-llamaindex): Partially reverts change to restore installation section

### DIFF
--- a/packages/toolbox-llamaindex/README.md
+++ b/packages/toolbox-llamaindex/README.md
@@ -39,6 +39,14 @@ applications, enabling advanced orchestration and interaction with GenAI models.
 
 <!-- /TOC -->
 
+## Installation
+
+```bash
+pip install toolbox-llamaindex
+```
+
+## Quickstart
+
 Here's a minimal example to get you started using
 [LlamaIndex](https://docs.llamaindex.ai/en/stable/#getting-started):
 


### PR DESCRIPTION
This PR partially reverts some changes from #265, that seems to mistakenly remove the installation section and quickstart heading.