### PR TITLE
chore(toolbox-core): Use Toolbox server dev build for integration tests

### DIFF
--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -33,6 +33,7 @@ steps:
     env:
       - TOOLBOX_URL=$_TOOLBOX_URL
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
+      - TOOLBOX_BUCKET=$_TOOLBOX_BUCKET
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID
     args:
       - '-c'
@@ -43,4 +44,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '0.8.0'
+  _TOOLBOX_VERSION: 'main'
+  _TOOLBOX_BUCKET: 'genai-toolbox-dev'

--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -44,5 +44,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: 'main'
+  _TOOLBOX_VERSION: 'latest'
   _TOOLBOX_BUCKET: 'genai-toolbox-dev'

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -101,6 +101,9 @@ def project_id() -> str:
 def toolbox_version() -> str:
     return get_env_var("TOOLBOX_VERSION")
 
+@pytest_asyncio.fixture(scope="session")
+def toolbox_bucket() -> str:
+    return get_env_var("TOOLBOX_BUCKET")
 
 @pytest_asyncio.fixture(scope="session")
 def tools_file_path(project_id: str) -> Generator[str]:
@@ -130,11 +133,11 @@ def auth_token2(project_id: str) -> str:
 
 
 @pytest_asyncio.fixture(scope="session")
-def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None]:
+def toolbox_server(toolbox_version: str, toolbox_bucket: str, tools_file_path: str) -> Generator[None]:
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("genai-toolbox", source_blob_name, "toolbox")
+    download_blob(toolbox_bucket, source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -75,7 +75,7 @@ def get_toolbox_binary_url(toolbox_version: str) -> str:
     arch = (
         "arm64" if os_system == "darwin" and platform.machine() == "arm64" else "amd64"
     )
-    return f"v{toolbox_version}/{os_system}/{arch}/toolbox"
+    return f"{toolbox_version}/{os_system}/{arch}/toolbox"
 
 
 def get_auth_token(client_id: str) -> str:

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -101,9 +101,11 @@ def project_id() -> str:
 def toolbox_version() -> str:
     return get_env_var("TOOLBOX_VERSION")
 
+
 @pytest_asyncio.fixture(scope="session")
 def toolbox_bucket() -> str:
     return get_env_var("TOOLBOX_BUCKET")
+
 
 @pytest_asyncio.fixture(scope="session")
 def tools_file_path(project_id: str) -> Generator[str]:
@@ -133,7 +135,9 @@ def auth_token2(project_id: str) -> str:
 
 
 @pytest_asyncio.fixture(scope="session")
-def toolbox_server(toolbox_version: str, toolbox_bucket: str, tools_file_path: str) -> Generator[None]:
+def toolbox_server(
+    toolbox_version: str, toolbox_bucket: str, tools_file_path: str
+) -> Generator[None]:
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)


### PR DESCRIPTION
This PR updates the integration tests to use a dev build of the toolbox server from the `main` branch.

Currently, integration tests are conducted against a released version of the toolbox server. This poses a challenge when SDK and server features, such as optional parameters, are developed and released concurrently. In such scenarios, integration tests for the SDK will fail as the corresponding server-side support is absent in the released version.

To address this, this change modifies the server download for integration tests to pull from the GCS bucket for toolbox dev builds, specifically from the `main` branch. This ensures that the SDK is tested against the latest server version, which should ideally be stable and backward-compatible.

## Flexibility in Versioning
For situations where new SDK features do not have a dependency on server-side changes, the `TOOLBOX_VERSION` and the newly introduced `TOOLBOX_BUCKET` env vars in the `integration.cloudbuild.yaml` config can be adjusted. This allows for switching back to a specific released version of the toolbox server for integration testing if needed.

> [!NOTE]
> This PR removes the automatic `v` prefix from the version when constructing the blob download URL. Consequently, if you need to test against a released version (e.g., `0.8.0`), the `TOOLBOX_VERSION` must be set to `v0.8.0`. This change accommodates version values that do not have a v prefix, such as `main`.

> [!NOTE]
> The integration tests would currently fail due to a known issue with the optional parameters implementation with the server dev build [[#771](https://github.com/googleapis/genai-toolbox/issues/771)]