### PR TITLE
docs(toolbox-core): Improve docstrings for context manager functions in sync client and auth module

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/auth_methods.py
+++ b/packages/toolbox-core/src/toolbox_core/auth_methods.py
@@ -20,11 +20,11 @@ Example User Experience:
 from toolbox_core import auth_methods
 
 auth_token_provider = auth_methods.aget_google_id_token
-toolbox = ToolboxClient(
+async with ToolboxClient(
     URL,
     client_headers={"Authorization": auth_token_provider},
-)
-tools = await toolbox.load_toolset()
+) as toolbox:
+    tools = await toolbox.load_toolset()
 """
 
 from datetime import datetime, timedelta, timezone

--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -176,9 +176,22 @@ class ToolboxSyncClient:
         self.__async_client.add_headers(headers)
 
     def __enter__(self):
-        """Enter the runtime context related to this client instance."""
+        """
+        Enter the runtime context related to this client instance.
+
+        Allows the client to be used as a context manager
+        (e.g., `with ToolboxSyncClient(...) as client:`).
+
+        Returns:
+            self: The client instance itself.
+        """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Exit the runtime context and close the client session."""
+        """
+        Exit the runtime context and close the internally managed session.
+
+        Allows the client to be used as a context manager
+        (e.g., `with ToolboxSyncClient(...) as client:`).
+        """
         self.close()


### PR DESCRIPTION
This PR updates docstrings for the context manager functions `__enter__` and `__exit__` methods in sync client, and also on the auth module, to use the context manager while initializing the client.