### PR TITLE
fix(core)!: Use ValueError for missing 'items' in array parameters

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -42,7 +42,7 @@ class ParameterSchema(BaseModel):
             base_type = bool
         elif self.type == "array":
             if self.items is None:
-                raise Exception("Unexpected value: type is 'list' but items is None")
+                raise ValueError("Unexpected value: type is 'array' but items is None")
             base_type = list[self.items.__get_type()]  # type: ignore
         else:
             raise ValueError(f"Unsupported schema type: {self.type}")

--- a/packages/toolbox-core/tests/test_protocol.py
+++ b/packages/toolbox-core/tests/test_protocol.py
@@ -86,11 +86,11 @@ def test_parameter_schema_array_no_items_error():
         name="bad_list", type="array", description="List without item type"
     )
 
-    expected_error_msg = "Unexpected value: type is 'list' but items is None"
-    with pytest.raises(Exception, match=expected_error_msg):
+    expected_error_msg = "Unexpected value: type is 'array' but items is None"
+    with pytest.raises(ValueError, match=expected_error_msg):
         schema._ParameterSchema__get_type()
 
-    with pytest.raises(Exception, match=expected_error_msg):
+    with pytest.raises(ValueError, match=expected_error_msg):
         schema.to_param()
 
 


### PR DESCRIPTION
## Overview
This PR improves the developer experience by providing more specific and actionable errors. When a tool parameter of type `array` was defined without its required `items` key, the SDK would raise a generic `Exception`. This made it difficult to distinguish this specific validation failure from other unexpected runtime exceptions.

This change corrects the behavior by raising a `ValueError`, which is the semantically appropriate exception for this scenario. The error message has also been slightly updated for consistency.

### Before
* Error Type: `Exception`
* Error Message: `"Unexpected value: type is 'list' but items is None"`

### After
* Error Type: `ValueError`
* Error Message: `"Unexpected value: type is 'array' but items is None"`

## Testing
The unit test `test_parameter_schema_array_no_items_error` has been updated to reflect these changes.