### PR TITLE
chore: remove redundant unit test

### DIFF
--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -473,35 +473,6 @@ def test_tool_add_auth_token_getters_conflict_with_existing_client_header(
         tool_instance.add_auth_token_getters(new_auth_getters_causing_conflict)
 
 
-def test_add_auth_token_getters_unused_token(
-    http_session: ClientSession,
-    sample_tool_params: list[ParameterSchema],
-    sample_tool_description: str,
-    unused_auth_getters: Mapping[str, Callable[[], str]],
-):
-    """
-    Tests ValueError when add_auth_token_getters is called with a getter for
-    an unused authentication service.
-    """
-    tool_instance = ToolboxTool(
-        session=http_session,
-        base_url=HTTPS_BASE_URL,
-        name=TEST_TOOL_NAME,
-        description=sample_tool_description,
-        params=sample_tool_params,
-        required_authn_params={},
-        required_authz_tokens=[],
-        auth_service_token_getters={},
-        bound_params={},
-        client_headers={},
-    )
-
-    expected_error_message = "Authentication source\(s\) \`unused-auth-service\` unused by tool \`sample_tool\`."
-
-    with pytest.raises(ValueError, match=expected_error_message):
-        tool_instance.add_auth_token_getters(unused_auth_getters)
-
-
 def test_add_auth_token_getter_unused_token(
     http_session: ClientSession,
     sample_tool_params: list[ParameterSchema],


### PR DESCRIPTION
This PR removes the redundant test [test_add_auth_token_getter_unused_token](https://github.com/Ganga4060/mcp-toolbox-sdk-python/blob/ffd8714c72497cf4ec01d0354d3eeb16ab48b9de/packages/toolbox-core/tests/test_tool.py#L476) from tests/test_tool.py.