### PR TITLE
test(tool): Add test for auth header override

### DIFF
--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -477,16 +477,16 @@ def test_tool_add_auth_token_getters_conflict_with_existing_client_header(
 async def test_auth_token_getter_overrides_client_header_in_runtime_conflict_concise(
     http_session: ClientSession,
     sample_tool_description: str,
-    sample_tool_auth_params: list[ParameterSchema], 
-    auth_token_value: str, # Use fixture for auth token value
-    auth_getters: dict, # Use fixture for auth getters
+    sample_tool_auth_params: list[ParameterSchema],
+    auth_token_value: str,  # Use fixture for auth token value
+    auth_getters: dict,  # Use fixture for auth getters
 ):
     """
     This test verifies that when both client headers and auth token getters
     produce the same header name, the auth token getter value takes precedence
     during actual tool invocation.
     """
-     
+
     tool_name = TEST_TOOL_NAME
     base_url = HTTPS_BASE_URL
     invoke_url = f"{base_url}/api/tool/{tool_name}/invoke"
@@ -496,9 +496,9 @@ async def test_auth_token_getter_overrides_client_header_in_runtime_conflict_con
     client_header_value = "client-provided-value"
     client_headers = {conflicting_header_name: client_header_value}
 
-    params_with_auth_source = sample_tool_auth_params # Renaming for clarity
+    params_with_auth_source = sample_tool_auth_params  # Renaming for clarity
 
-    input_args = {"target": "test_target", "token": "dummy_token"} 
+    input_args = {"target": "test_target", "token": "dummy_token"}
     mock_server_response = {"result": "Auth success"}
 
     with aioresponses() as m:
@@ -518,7 +518,9 @@ async def test_auth_token_getter_overrides_client_header_in_runtime_conflict_con
         )
 
         original_get_auth_header = tool_instance._ToolboxTool__get_auth_header
-        tool_instance._ToolboxTool__get_auth_header = lambda auth_service: conflicting_header_name
+        tool_instance._ToolboxTool__get_auth_header = (
+            lambda auth_service: conflicting_header_name
+        )
 
         result = await tool_instance(**input_args)
 
@@ -528,8 +530,8 @@ async def test_auth_token_getter_overrides_client_header_in_runtime_conflict_con
         m.assert_called_once_with(
             invoke_url,
             method="POST",
-            json=input_args, # The payload is the input_args
-            headers={conflicting_header_name: auth_token_value}
+            json=input_args,  # The payload is the input_args
+            headers={conflicting_header_name: auth_token_value},
         )
 
         # Restore original method

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -473,35 +473,6 @@ def test_tool_add_auth_token_getters_conflict_with_existing_client_header(
         tool_instance.add_auth_token_getters(new_auth_getters_causing_conflict)
 
 
-def test_add_auth_token_getters_unused_token(
-    http_session: ClientSession,
-    sample_tool_params: list[ParameterSchema],
-    sample_tool_description: str,
-    unused_auth_getters: Mapping[str, Callable[[], str]],
-):
-    """
-    Tests ValueError when add_auth_token_getters is called with a getter for
-    an unused authentication service.
-    """
-    tool_instance = ToolboxTool(
-        session=http_session,
-        base_url=HTTPS_BASE_URL,
-        name=TEST_TOOL_NAME,
-        description=sample_tool_description,
-        params=sample_tool_params,
-        required_authn_params={},
-        required_authz_tokens=[],
-        auth_service_token_getters={},
-        bound_params={},
-        client_headers={},
-    )
-
-    expected_error_message = "Authentication source\(s\) \`unused-auth-service\` unused by tool \`sample_tool\`."
-
-    with pytest.raises(ValueError, match=expected_error_message):
-        tool_instance.add_auth_token_getters(unused_auth_getters)
-
-
 def test_add_auth_token_getter_unused_token(
     http_session: ClientSession,
     sample_tool_params: list[ParameterSchema],

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -473,6 +473,69 @@ def test_tool_add_auth_token_getters_conflict_with_existing_client_header(
         tool_instance.add_auth_token_getters(new_auth_getters_causing_conflict)
 
 
+@pytest.mark.asyncio
+async def test_auth_token_getter_overrides_client_header_in_runtime_conflict_concise(
+    http_session: ClientSession,
+    sample_tool_description: str,
+    sample_tool_auth_params: list[ParameterSchema], 
+    auth_token_value: str, # Use fixture for auth token value
+    auth_getters: dict, # Use fixture for auth getters
+):
+    """
+    This test verifies that when both client headers and auth token getters
+    produce the same header name, the auth token getter value takes precedence
+    during actual tool invocation.
+    """
+     
+    tool_name = TEST_TOOL_NAME
+    base_url = HTTPS_BASE_URL
+    invoke_url = f"{base_url}/api/tool/{tool_name}/invoke"
+
+    # Define the conflicting header name and client-provided value
+    conflicting_header_name = "X-Conflict-Header"
+    client_header_value = "client-provided-value"
+    client_headers = {conflicting_header_name: client_header_value}
+
+    params_with_auth_source = sample_tool_auth_params # Renaming for clarity
+
+    input_args = {"target": "test_target", "token": "dummy_token"} 
+    mock_server_response = {"result": "Auth success"}
+
+    with aioresponses() as m:
+        m.post(invoke_url, status=200, payload=mock_server_response)
+
+        tool_instance = ToolboxTool(
+            session=http_session,
+            base_url=base_url,
+            name=tool_name,
+            description=sample_tool_description,
+            params=params_with_auth_source,
+            required_authn_params={},
+            required_authz_tokens=[],
+            auth_service_token_getters=auth_getters,
+            bound_params={},
+            client_headers=client_headers,
+        )
+
+        original_get_auth_header = tool_instance._ToolboxTool__get_auth_header
+        tool_instance._ToolboxTool__get_auth_header = lambda auth_service: conflicting_header_name
+
+        result = await tool_instance(**input_args)
+
+        assert result == mock_server_response["result"]
+
+        # Verify the request was made with the auth token value overriding the client header
+        m.assert_called_once_with(
+            invoke_url,
+            method="POST",
+            json=input_args, # The payload is the input_args
+            headers={conflicting_header_name: auth_token_value}
+        )
+
+        # Restore original method
+        tool_instance._ToolboxTool__get_auth_header = original_get_auth_header
+
+
 def test_add_auth_token_getter_unused_token(
     http_session: ClientSession,
     sample_tool_params: list[ParameterSchema],

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -474,7 +474,7 @@ def test_tool_add_auth_token_getters_conflict_with_existing_client_header(
 
 
 @pytest.mark.asyncio
-async def test_auth_token_getter_overrides_client_header_in_runtime_conflict_concise(
+async def test_auth_token_getter_overrides_client_header(
     http_session: ClientSession,
     sample_tool_description: str,
     sample_tool_auth_params: list[ParameterSchema],


### PR DESCRIPTION
"This PR adds a unit test to verify that an auth token getter's value correctly overrides a client header value during a runtime name conflict, ensuring authentication headers have precedence."