### PR TITLE
fix(toolbox-core): Use typing.Annotated for reliable parameter descriptions instead of docstrings

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from inspect import Parameter
-from typing import Any, Optional, Type, Union
+from typing import Annotated, Any, Optional, Type, Union
 
 from pydantic import BaseModel
 
@@ -76,9 +76,9 @@ class ParameterSchema(BaseModel):
             base_type = _get_python_type(self.type)
 
         if not self.required:
-            return Optional[base_type]  # type: ignore
+            base_type = Optional[base_type]
 
-        return base_type
+        return Annotated[base_type, self.description]
 
     def to_param(self) -> Parameter:
         return Parameter(

--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -60,12 +60,12 @@ class ParameterSchema(BaseModel):
     items: Optional["ParameterSchema"] = None
     additionalProperties: Optional[Union[bool, AdditionalPropertiesSchema]] = None
 
-    def __get_type(self) -> Any:
+    def __get_annotation(self) -> Any:
         base_type: Any
         if self.type == "array":
             if self.items is None:
                 raise ValueError("Unexpected value: type is 'array' but items is None")
-            base_type = list[self.items.__get_type()]  # type: ignore
+            base_type = list[self.items.__get_annotation()]  # type: ignore
         elif self.type == "object":
             if isinstance(self.additionalProperties, AdditionalPropertiesSchema):
                 value_type = self.additionalProperties.get_value_type()
@@ -84,7 +84,7 @@ class ParameterSchema(BaseModel):
         return Parameter(
             self.name,
             Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=self.__get_type(),
+            annotation=self.__get_annotation(),
             default=Parameter.empty if self.required else None,
         )
 

--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -60,8 +60,8 @@ class ParameterSchema(BaseModel):
     items: Optional["ParameterSchema"] = None
     additionalProperties: Optional[Union[bool, AdditionalPropertiesSchema]] = None
 
-    def __get_type(self) -> Type:
-        base_type: Type
+    def __get_type(self) -> Any:
+        base_type: Any
         if self.type == "array":
             if self.items is None:
                 raise ValueError("Unexpected value: type is 'array' but items is None")

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -24,7 +24,6 @@ from aiohttp import ClientSession
 
 from .protocol import ParameterSchema
 from .utils import (
-    create_func_docstring,
     identify_auth_requirements,
     params_to_pydantic_model,
     resolve_value,
@@ -101,7 +100,7 @@ class ToolboxTool:
 
         # the following properties are set to help anyone that might inspect it determine usage
         self.__name__ = name
-        self.__doc__ = create_func_docstring(self.__description, self.__params)
+        self.__doc__ = self.__description
         self.__signature__ = Signature(
             parameters=inspect_type_params, return_annotation=str
         )

--- a/packages/toolbox-core/src/toolbox_core/utils.py
+++ b/packages/toolbox-core/src/toolbox_core/utils.py
@@ -31,18 +31,6 @@ from pydantic import BaseModel, Field, create_model
 from toolbox_core.protocol import ParameterSchema
 
 
-def create_func_docstring(description: str, params: Sequence[ParameterSchema]) -> str:
-    """Convert tool description and params into its function docstring"""
-    docstring = description
-    if not params:
-        return docstring
-    docstring += "\n\nArgs:"
-    for p in params:
-        annotation = p.to_param().annotation
-        docstring += f"\n    {p.name} ({getattr(annotation, '__name__', str(annotation))}): {p.description}"
-    return docstring
-
-
 def identify_auth_requirements(
     req_authn_params: Mapping[str, list[str]],
     req_authz_tokens: Sequence[str],

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -15,8 +15,7 @@
 
 import inspect
 import json
-from typing import Any, Callable, Mapping, Optional, Annotated, get_args, get_origin
-
+from typing import Annotated, Any, Callable, Mapping, Optional, get_args, get_origin
 from unittest.mock import AsyncMock, Mock
 
 import pytest

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -15,7 +15,8 @@
 
 import inspect
 import json
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional, Annotated, get_args, get_origin
+
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -192,15 +193,30 @@ async def test_load_tool_success(aioresponses, test_tool_str):
         assert callable(loaded_tool)
         # Assert introspection attributes are set correctly
         assert loaded_tool.__name__ == TOOL_NAME
-        expected_description = (
-            test_tool_str.description
-            + f"\n\nArgs:\n    param1 (str): Description of Param1"
-        )
+        expected_description = test_tool_str.description
         assert loaded_tool.__doc__ == expected_description
 
-        # Assert signature inspection
+        # Assert signature inspection, including annotated descriptions
         sig = inspect.signature(loaded_tool)
-        assert list(sig.parameters.keys()) == [p.name for p in test_tool_str.parameters]
+        actual_params_map = sig.parameters
+        expected_params_list = test_tool_str.parameters
+
+        assert len(actual_params_map) == len(expected_params_list)
+
+        for expected_param_schema in expected_params_list:
+            param_name = expected_param_schema.name
+            assert param_name in actual_params_map
+            actual_param = actual_params_map[param_name]
+            annotation = actual_param.annotation
+            assert get_origin(annotation) is Annotated
+            annotation_args = get_args(annotation)
+            actual_param_description = annotation_args[1]
+            assert actual_param_description == expected_param_schema.description
+
+            if expected_param_schema.required:
+                assert actual_param.default is inspect.Parameter.empty
+            else:
+                assert actual_param.default is None
 
         assert await loaded_tool("some value") == "ok"
 

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from inspect import Parameter, signature
-from typing import Any, Optional
+from typing import Any, Optional, Annotated
 
 import pytest
 import pytest_asyncio
@@ -243,7 +243,7 @@ class TestOptionalParams:
 
         # The required parameter should have no default
         assert sig.parameters["email"].default is Parameter.empty
-        assert sig.parameters["email"].annotation is str
+        assert sig.parameters["email"].annotation is Annotated[str, 'The email to search for.']
 
         # The optional parameter should have a default of None
         assert sig.parameters["data"].default is None
@@ -395,7 +395,7 @@ class TestMapParams:
         sig = signature(tool)
 
         assert "execution_context" in sig.parameters
-        assert sig.parameters["execution_context"].annotation == dict[str, Any]
+        assert sig.parameters["execution_context"].annotation == Annotated[dict[str, Any], 'A flexible set of key-value pairs for the execution environment.']
         assert sig.parameters["execution_context"].default is Parameter.empty
 
         assert "user_scores" in sig.parameters

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -257,7 +257,10 @@ class TestOptionalParams:
 
         # The optional parameter should have a default of None
         assert sig.parameters["id"].default is None
-        assert sig.parameters["id"].annotation is Optional[int]
+        assert (
+            sig.parameters["id"].annotation
+            is Annotated[Optional[int], "The id to narrow down the search."]
+        )
 
     async def test_run_tool_with_optional_params_omitted(self, toolbox: ToolboxClient):
         """Invoke a tool providing only the required parameter."""
@@ -418,7 +421,10 @@ class TestMapParams:
         assert sig.parameters["user_scores"].default is Parameter.empty
 
         assert "feature_flags" in sig.parameters
-        assert sig.parameters["feature_flags"].annotation == Optional[dict[str, bool]]
+        assert (
+            sig.parameters["feature_flags"].annotation
+            == Annotated[Optional[dict[str, bool]], "Optional feature flags."]
+        )
         assert sig.parameters["feature_flags"].default is None
 
     async def test_run_tool_with_map_params(self, toolbox: ToolboxClient):

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from inspect import Parameter, signature
-from typing import Any, Optional, Annotated
+from typing import Annotated, Any, Optional
 
 import pytest
 import pytest_asyncio
@@ -243,7 +243,10 @@ class TestOptionalParams:
 
         # The required parameter should have no default
         assert sig.parameters["email"].default is Parameter.empty
-        assert sig.parameters["email"].annotation is Annotated[str, 'The email to search for.']
+        assert (
+            sig.parameters["email"].annotation
+            is Annotated[str, "The email to search for."]
+        )
 
         # The optional parameter should have a default of None
         assert sig.parameters["data"].default is None
@@ -395,7 +398,13 @@ class TestMapParams:
         sig = signature(tool)
 
         assert "execution_context" in sig.parameters
-        assert sig.parameters["execution_context"].annotation == Annotated[dict[str, Any], 'A flexible set of key-value pairs for the execution environment.']
+        assert (
+            sig.parameters["execution_context"].annotation
+            == Annotated[
+                dict[str, Any],
+                "A flexible set of key-value pairs for the execution environment.",
+            ]
+        )
         assert sig.parameters["execution_context"].default is Parameter.empty
 
         assert "user_scores" in sig.parameters

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -250,7 +250,10 @@ class TestOptionalParams:
 
         # The optional parameter should have a default of None
         assert sig.parameters["data"].default is None
-        assert sig.parameters["data"].annotation is Optional[str]
+        assert (
+            sig.parameters["data"].annotation
+            is Annotated[Optional[str], "The row to narrow down the search."]
+        )
 
         # The optional parameter should have a default of None
         assert sig.parameters["id"].default is None
@@ -408,7 +411,10 @@ class TestMapParams:
         assert sig.parameters["execution_context"].default is Parameter.empty
 
         assert "user_scores" in sig.parameters
-        assert sig.parameters["user_scores"].annotation == dict[str, int]
+        assert (
+            sig.parameters["user_scores"].annotation
+            == Annotated[dict[str, int], "A map of user IDs to their scores."]
+        )
         assert sig.parameters["user_scores"].default is Parameter.empty
 
         assert "feature_flags" in sig.parameters

--- a/packages/toolbox-core/tests/test_protocol.py
+++ b/packages/toolbox-core/tests/test_protocol.py
@@ -14,7 +14,7 @@
 
 
 from inspect import Parameter
-from typing import Any, Optional
+from typing import Any, Optional, Annotated, get_args, get_origin
 
 import pytest
 
@@ -25,15 +25,18 @@ def test_parameter_schema_float():
     """Tests ParameterSchema with type 'float'."""
     schema = ParameterSchema(name="price", type="float", description="The item price")
     expected_type = float
-    assert schema._ParameterSchema__get_type() == expected_type
 
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "price"
-    assert param.annotation == expected_type
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
     assert param.default == Parameter.empty
 
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 def test_parameter_schema_boolean():
     """Tests ParameterSchema with type 'boolean'."""
@@ -41,43 +44,58 @@ def test_parameter_schema_boolean():
         name="is_active", type="boolean", description="Activity status"
     )
     expected_type = bool
-    assert schema._ParameterSchema__get_type() == expected_type
 
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "is_active"
-    assert param.annotation == expected_type
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
 
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 def test_parameter_schema_array_string():
     """Tests ParameterSchema with type 'array' containing strings."""
-    item_schema = ParameterSchema(name="", type="string", description="")
+    item_schema = ParameterSchema(name="", type="string", description="item desc")
     schema = ParameterSchema(
         name="tags", type="array", description="List of tags", items=item_schema
     )
 
-    assert schema._ParameterSchema__get_type() == list[str]
+    expected_base_type = list[Annotated[str, item_schema.description]]
 
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "tags"
-    assert param.annotation == list[str]
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_base_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_array_integer():
     """Tests ParameterSchema with type 'array' containing integers."""
-    item_schema = ParameterSchema(name="", type="integer", description="")
+    item_schema = ParameterSchema(name="", type="integer", description="score item")
     schema = ParameterSchema(
         name="scores", type="array", description="List of scores", items=item_schema
     )
+    
+    expected_base_type = list[Annotated[int, item_schema.description]]
 
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "scores"
-    assert param.annotation == list[int]
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
+    
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_base_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_array_no_items_error():
@@ -119,16 +137,17 @@ def test_parameter_schema_string_optional():
     )
     expected_type = Optional[str]
 
-    # Test __get_type()
-    assert schema._ParameterSchema__get_type() == expected_type
-
-    # Test to_param()
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "nickname"
-    assert param.annotation == expected_type
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
     assert param.default is None
+    
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_required_by_default():
@@ -137,20 +156,21 @@ def test_parameter_schema_required_by_default():
     schema = ParameterSchema(name="id", type="integer", description="A required ID")
     expected_type = int
 
-    # Test __get_type()
-    assert schema._ParameterSchema__get_type() == expected_type
-
-    # Test to_param()
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "id"
-    assert param.annotation == expected_type
     assert param.default == Parameter.empty
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_array_optional():
     """Tests an optional ParameterSchema with type 'array'."""
-    item_schema = ParameterSchema(name="", type="integer", description="")
+    item_schema = ParameterSchema(name="", type="integer", description="item")
     schema = ParameterSchema(
         name="optional_scores",
         type="array",
@@ -158,18 +178,20 @@ def test_parameter_schema_array_optional():
         items=item_schema,
         required=False,
     )
-    expected_type = Optional[list[int]]
 
-    # Test __get_type()
-    assert schema._ParameterSchema__get_type() == expected_type
+    expected_base_type = Optional[list[Annotated[int, item_schema.description]]]
 
-    # Test to_param()
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "optional_scores"
-    assert param.annotation == expected_type
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
     assert param.default is None
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_base_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_generic():
@@ -181,13 +203,17 @@ def test_parameter_schema_map_generic():
         additionalProperties=True,
     )
     expected_type = dict[str, Any]
-    assert schema._ParameterSchema__get_type() == expected_type
 
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "metadata"
-    assert param.annotation == expected_type
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_typed_string():
@@ -199,10 +225,14 @@ def test_parameter_schema_map_typed_string():
         additionalProperties=AdditionalPropertiesSchema(type="string"),
     )
     expected_type = dict[str, str]
-    assert schema._ParameterSchema__get_type() == expected_type
 
     param = schema.to_param()
-    assert param.annotation == expected_type
+    
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_typed_integer():
@@ -214,9 +244,14 @@ def test_parameter_schema_map_typed_integer():
         additionalProperties=AdditionalPropertiesSchema(type="integer"),
     )
     expected_type = dict[str, int]
-    assert schema._ParameterSchema__get_type() == expected_type
+    
     param = schema.to_param()
-    assert param.annotation == expected_type
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_typed_float():
@@ -228,9 +263,14 @@ def test_parameter_schema_map_typed_float():
         additionalProperties=AdditionalPropertiesSchema(type="float"),
     )
     expected_type = dict[str, float]
-    assert schema._ParameterSchema__get_type() == expected_type
+
     param = schema.to_param()
-    assert param.annotation == expected_type
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_typed_boolean():
@@ -242,9 +282,14 @@ def test_parameter_schema_map_typed_boolean():
         additionalProperties=AdditionalPropertiesSchema(type="boolean"),
     )
     expected_type = dict[str, bool]
-    assert schema._ParameterSchema__get_type() == expected_type
+
     param = schema.to_param()
-    assert param.annotation == expected_type
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_optional():
@@ -257,10 +302,15 @@ def test_parameter_schema_map_optional():
         additionalProperties=True,
     )
     expected_type = Optional[dict[str, Any]]
-    assert schema._ParameterSchema__get_type() == expected_type
+    
     param = schema.to_param()
-    assert param.annotation == expected_type
     assert param.default is None
+
+    annotation = param.annotation
+    assert get_origin(annotation) is Annotated
+    args = get_args(annotation)
+    assert args[0] == expected_type
+    assert args[1] == schema.description
 
 
 def test_parameter_schema_map_unsupported_value_type_error():
@@ -270,7 +320,6 @@ def test_parameter_schema_map_unsupported_value_type_error():
         name="custom_data",
         type="object",
         description="Custom data map",
-        valueType=unsupported_type,
         additionalProperties=AdditionalPropertiesSchema(type=unsupported_type),
     )
     expected_error_msg = f"Unsupported schema type: {unsupported_type}"

--- a/packages/toolbox-core/tests/test_protocol.py
+++ b/packages/toolbox-core/tests/test_protocol.py
@@ -14,7 +14,7 @@
 
 
 from inspect import Parameter
-from typing import Any, Optional, Annotated, get_args, get_origin
+from typing import Annotated, Any, Optional, get_args, get_origin
 
 import pytest
 
@@ -38,6 +38,7 @@ def test_parameter_schema_float():
     assert args[0] == expected_type
     assert args[1] == schema.description
 
+
 def test_parameter_schema_boolean():
     """Tests ParameterSchema with type 'boolean'."""
     schema = ParameterSchema(
@@ -55,6 +56,7 @@ def test_parameter_schema_boolean():
     args = get_args(annotation)
     assert args[0] == expected_type
     assert args[1] == schema.description
+
 
 def test_parameter_schema_array_string():
     """Tests ParameterSchema with type 'array' containing strings."""
@@ -83,14 +85,14 @@ def test_parameter_schema_array_integer():
     schema = ParameterSchema(
         name="scores", type="array", description="List of scores", items=item_schema
     )
-    
+
     expected_base_type = list[Annotated[int, item_schema.description]]
 
     param = schema.to_param()
     assert isinstance(param, Parameter)
     assert param.name == "scores"
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
-    
+
     annotation = param.annotation
     assert get_origin(annotation) is Annotated
     args = get_args(annotation)
@@ -142,7 +144,7 @@ def test_parameter_schema_string_optional():
     assert param.name == "nickname"
     assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
     assert param.default is None
-    
+
     annotation = param.annotation
     assert get_origin(annotation) is Annotated
     args = get_args(annotation)
@@ -227,7 +229,7 @@ def test_parameter_schema_map_typed_string():
     expected_type = dict[str, str]
 
     param = schema.to_param()
-    
+
     annotation = param.annotation
     assert get_origin(annotation) is Annotated
     args = get_args(annotation)
@@ -244,7 +246,7 @@ def test_parameter_schema_map_typed_integer():
         additionalProperties=AdditionalPropertiesSchema(type="integer"),
     )
     expected_type = dict[str, int]
-    
+
     param = schema.to_param()
 
     annotation = param.annotation
@@ -302,7 +304,7 @@ def test_parameter_schema_map_optional():
         additionalProperties=True,
     )
     expected_type = Optional[dict[str, Any]]
-    
+
     param = schema.to_param()
     assert param.default is None
 

--- a/packages/toolbox-core/tests/test_protocol.py
+++ b/packages/toolbox-core/tests/test_protocol.py
@@ -108,7 +108,7 @@ def test_parameter_schema_array_no_items_error():
 
     expected_error_msg = "Unexpected value: type is 'array' but items is None"
     with pytest.raises(ValueError, match=expected_error_msg):
-        schema._ParameterSchema__get_type()
+        schema._ParameterSchema__get_annotation()
 
     with pytest.raises(ValueError, match=expected_error_msg):
         schema.to_param()
@@ -123,7 +123,7 @@ def test_parameter_schema_unsupported_type_error():
 
     expected_error_msg = f"Unsupported schema type: {unsupported_type}"
     with pytest.raises(ValueError, match=expected_error_msg):
-        schema._ParameterSchema__get_type()
+        schema._ParameterSchema__get_annotation()
 
     with pytest.raises(ValueError, match=expected_error_msg):
         schema.to_param()
@@ -326,4 +326,4 @@ def test_parameter_schema_map_unsupported_value_type_error():
     )
     expected_error_msg = f"Unsupported schema type: {unsupported_type}"
     with pytest.raises(ValueError, match=expected_error_msg):
-        schema._ParameterSchema__get_type()
+        schema._ParameterSchema__get_annotation()

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -26,7 +26,7 @@ from aioresponses import aioresponses
 from pydantic import ValidationError
 
 from toolbox_core.protocol import ParameterSchema
-from toolbox_core.tool import ToolboxTool, create_func_docstring, resolve_value
+from toolbox_core.tool import ToolboxTool, resolve_value
 
 TEST_BASE_URL = "http://toolbox.example.com"
 HTTPS_BASE_URL = "https://toolbox.example.com"
@@ -122,91 +122,6 @@ def toolbox_tool(
         bound_params={"fixed_param": "fixed_value"},
         client_headers={"X-Test-Client": "client_header_value"},
     )
-
-
-def test_create_func_docstring_one_param_real_schema():
-    """
-    Tests create_func_docstring with one real ParameterSchema instance.
-    """
-    description = "This tool does one thing."
-    params = [
-        ParameterSchema(
-            name="input_file", type="string", description="Path to the input file."
-        )
-    ]
-
-    result_docstring = create_func_docstring(description, params)
-
-    expected_docstring = (
-        "This tool does one thing.\n\n"
-        "Args:\n"
-        "    input_file (str): Path to the input file."
-    )
-
-    assert result_docstring == expected_docstring
-
-
-def test_create_func_docstring_multiple_params_real_schema():
-    """
-    Tests create_func_docstring with multiple real ParameterSchema instances.
-    """
-    description = "This tool does multiple things."
-    params = [
-        ParameterSchema(name="query", type="string", description="The search query."),
-        ParameterSchema(
-            name="max_results", type="integer", description="Maximum results to return."
-        ),
-        ParameterSchema(
-            name="verbose", type="boolean", description="Enable verbose output."
-        ),
-    ]
-
-    result_docstring = create_func_docstring(description, params)
-
-    expected_docstring = (
-        "This tool does multiple things.\n\n"
-        "Args:\n"
-        "    query (str): The search query.\n"
-        "    max_results (int): Maximum results to return.\n"
-        "    verbose (bool): Enable verbose output."
-    )
-
-    assert result_docstring == expected_docstring
-
-
-def test_create_func_docstring_no_description_real_schema():
-    """
-    Tests create_func_docstring with empty description and one real ParameterSchema.
-    """
-    description = ""
-    params = [
-        ParameterSchema(
-            name="config_id", type="string", description="The ID of the configuration."
-        )
-    ]
-
-    result_docstring = create_func_docstring(description, params)
-
-    expected_docstring = (
-        "\n\nArgs:\n" "    config_id (str): The ID of the configuration."
-    )
-
-    assert result_docstring == expected_docstring
-    assert result_docstring.startswith("\n\nArgs:")
-    assert "config_id (str): The ID of the configuration." in result_docstring
-
-
-def test_create_func_docstring_no_params():
-    """
-    Tests create_func_docstring when the params list is empty.
-    """
-    description = "This is a tool description."
-    params = []
-
-    result_docstring = create_func_docstring(description, params)
-
-    assert result_docstring == description
-    assert "\n\nArgs:" not in result_docstring
 
 
 @pytest.mark.asyncio

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -15,7 +15,7 @@
 
 import inspect
 from types import MappingProxyType
-from typing import AsyncGenerator, Callable, Mapping
+from typing import Annotated, AsyncGenerator, Callable, Mapping
 from unittest.mock import AsyncMock, Mock
 from warnings import catch_warnings, simplefilter
 
@@ -162,8 +162,14 @@ async def test_tool_creation_callable_and_run(
 
         assert "message" in tool_instance.__signature__.parameters
         assert "count" in tool_instance.__signature__.parameters
-        assert tool_instance.__signature__.parameters["message"].annotation == str
-        assert tool_instance.__signature__.parameters["count"].annotation == int
+        assert (
+            tool_instance.__signature__.parameters["message"].annotation
+            == Annotated[str, "A message to process"]
+        )
+        assert (
+            tool_instance.__signature__.parameters["count"].annotation
+            == Annotated[int, "A number"]
+        )
 
         actual_result = await tool_instance("hello world", 5)
 

--- a/packages/toolbox-core/tests/test_utils.py
+++ b/packages/toolbox-core/tests/test_utils.py
@@ -22,7 +22,6 @@ from pydantic import BaseModel, ValidationError
 
 from toolbox_core.protocol import ParameterSchema
 from toolbox_core.utils import (
-    create_func_docstring,
     identify_auth_requirements,
     params_to_pydantic_model,
     resolve_value,
@@ -41,46 +40,6 @@ def create_param_mock(name: str, description: str, annotation: Type) -> Mock:
 
     param_mock.to_param.return_value = mock_param_info
     return param_mock
-
-
-def test_create_func_docstring_no_params():
-    """Test create_func_docstring with no parameters."""
-    description = "This is a tool description."
-    params = []
-    expected_docstring = "This is a tool description."
-    assert create_func_docstring(description, params) == expected_docstring
-
-
-def test_create_func_docstring_with_params():
-    """Test create_func_docstring with multiple parameters using mocks."""
-    description = "Tool description."
-    params = [
-        create_param_mock(
-            name="param1", description="First parameter.", annotation=str
-        ),
-        create_param_mock(name="count", description="A number.", annotation=int),
-    ]
-    expected_docstring = """Tool description.
-
-Args:
-    param1 (str): First parameter.
-    count (int): A number."""
-    assert create_func_docstring(description, params) == expected_docstring
-
-
-def test_create_func_docstring_empty_description():
-    """Test create_func_docstring with an empty description using mocks."""
-    description = ""
-    params = [
-        create_param_mock(
-            name="param1", description="First parameter.", annotation=str
-        ),
-    ]
-    expected_docstring = """
-
-Args:
-    param1 (str): First parameter."""
-    assert create_func_docstring(description, params) == expected_docstring
 
 
 def test_identify_auth_requirements_none_required():


### PR DESCRIPTION
Fixes https://github.com/googleapis/genai-toolbox/issues/1327

# Overview

This PR refactors how `toolbox-core` handles tool parameter descriptions, moving them from dynamically generated docstrings directly into the function signature itself using `typing.Annotated`.

# Problem

Previously, our approach involved using the `create_func_docstring` utility to dynamically build a Google-style `Args:` section within the ToolboxTool function's docstring. This method was unreliable and required custom logic just to format correctly (https://github.com/googleapis/mcp-toolbox-sdk-python/pull/369).

We found this approach to be extremely flaky, as it depended entirely on downstream orchestrators (like LangChain and LlamaIndex) to successfully parse that specific docstring format. This led to bugs, such as orchestrations showing parameter descriptions twice, or (as seen specifically with LlamaIndex) failing to parse the descriptions at all.

# Solution

This PR implements a much cleaner and more reliable solution. We now modify ParameterSchema.__get_type (in protocol.py) to wrap the base Python type directly with typing.Annotated, passing the parameter description as the second argument.

For example, a parameter signature that was previously just:
```py
param1: str (with the description hidden in the docstring)
```

...is now natively represented in the signature as:
```py
param1: Annotated[str, "The description of param1"]
```

This is the standard, modern Python way to attach metadata to types. Frameworks like LlamaIndex and LangChain (via Pydantic) are built to introspect Annotated natively, ensuring descriptions are picked up reliably without buggy docstring parsing.

As an added benefit, this simplifies the codebase significantly, allowing us to remove the custom create_func_docstring utility and all of its associated test cases.

> [!NOTE]
> This feature is available as our minimum supported version is Python 3.9, where `Annotated` was introduced ([PEP 593](https://peps.python.org/pep-0593/)).