### PR TITLE
Revert "fix(toolbox-core): Use typing.Annotated for reliable parameter descriptions instead of docstrings"

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from inspect import Parameter
-from typing import Annotated, Any, Optional, Type, Union
+from typing import Any, Optional, Type, Union
 
 from pydantic import BaseModel
 
@@ -60,12 +60,12 @@ class ParameterSchema(BaseModel):
     items: Optional["ParameterSchema"] = None
     additionalProperties: Optional[Union[bool, AdditionalPropertiesSchema]] = None
 
-    def __get_annotation(self) -> Any:
-        base_type: Any
+    def __get_type(self) -> Type:
+        base_type: Type
         if self.type == "array":
             if self.items is None:
                 raise ValueError("Unexpected value: type is 'array' but items is None")
-            base_type = list[self.items.__get_annotation()]  # type: ignore
+            base_type = list[self.items.__get_type()]  # type: ignore
         elif self.type == "object":
             if isinstance(self.additionalProperties, AdditionalPropertiesSchema):
                 value_type = self.additionalProperties.get_value_type()
@@ -76,15 +76,15 @@ class ParameterSchema(BaseModel):
             base_type = _get_python_type(self.type)
 
         if not self.required:
-            base_type = Optional[base_type]
+            return Optional[base_type]  # type: ignore
 
-        return Annotated[base_type, self.description]
+        return base_type
 
     def to_param(self) -> Parameter:
         return Parameter(
             self.name,
             Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=self.__get_annotation(),
+            annotation=self.__get_type(),
             default=Parameter.empty if self.required else None,
         )
 

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -24,6 +24,7 @@ from aiohttp import ClientSession
 
 from .protocol import ParameterSchema
 from .utils import (
+    create_func_docstring,
     identify_auth_requirements,
     params_to_pydantic_model,
     resolve_value,
@@ -100,7 +101,7 @@ class ToolboxTool:
 
         # the following properties are set to help anyone that might inspect it determine usage
         self.__name__ = name
-        self.__doc__ = self.__description
+        self.__doc__ = create_func_docstring(self.__description, self.__params)
         self.__signature__ = Signature(
             parameters=inspect_type_params, return_annotation=str
         )

--- a/packages/toolbox-core/src/toolbox_core/utils.py
+++ b/packages/toolbox-core/src/toolbox_core/utils.py
@@ -31,6 +31,18 @@ from pydantic import BaseModel, Field, create_model
 from toolbox_core.protocol import ParameterSchema
 
 
+def create_func_docstring(description: str, params: Sequence[ParameterSchema]) -> str:
+    """Convert tool description and params into its function docstring"""
+    docstring = description
+    if not params:
+        return docstring
+    docstring += "\n\nArgs:"
+    for p in params:
+        annotation = p.to_param().annotation
+        docstring += f"\n    {p.name} ({getattr(annotation, '__name__', str(annotation))}): {p.description}"
+    return docstring
+
+
 def identify_auth_requirements(
     req_authn_params: Mapping[str, list[str]],
     req_authz_tokens: Sequence[str],

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -15,7 +15,7 @@
 
 import inspect
 import json
-from typing import Annotated, Any, Callable, Mapping, Optional, get_args, get_origin
+from typing import Any, Callable, Mapping, Optional
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -192,30 +192,15 @@ async def test_load_tool_success(aioresponses, test_tool_str):
         assert callable(loaded_tool)
         # Assert introspection attributes are set correctly
         assert loaded_tool.__name__ == TOOL_NAME
-        expected_description = test_tool_str.description
+        expected_description = (
+            test_tool_str.description
+            + f"\n\nArgs:\n    param1 (str): Description of Param1"
+        )
         assert loaded_tool.__doc__ == expected_description
 
-        # Assert signature inspection, including annotated descriptions
+        # Assert signature inspection
         sig = inspect.signature(loaded_tool)
-        actual_params_map = sig.parameters
-        expected_params_list = test_tool_str.parameters
-
-        assert len(actual_params_map) == len(expected_params_list)
-
-        for expected_param_schema in expected_params_list:
-            param_name = expected_param_schema.name
-            assert param_name in actual_params_map
-            actual_param = actual_params_map[param_name]
-            annotation = actual_param.annotation
-            assert get_origin(annotation) is Annotated
-            annotation_args = get_args(annotation)
-            actual_param_description = annotation_args[1]
-            assert actual_param_description == expected_param_schema.description
-
-            if expected_param_schema.required:
-                assert actual_param.default is inspect.Parameter.empty
-            else:
-                assert actual_param.default is None
+        assert list(sig.parameters.keys()) == [p.name for p in test_tool_str.parameters]
 
         assert await loaded_tool("some value") == "ok"
 

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from inspect import Parameter, signature
-from typing import Annotated, Any, Optional
+from typing import Any, Optional
 
 import pytest
 import pytest_asyncio
@@ -243,24 +243,15 @@ class TestOptionalParams:
 
         # The required parameter should have no default
         assert sig.parameters["email"].default is Parameter.empty
-        assert (
-            sig.parameters["email"].annotation
-            is Annotated[str, "The email to search for."]
-        )
+        assert sig.parameters["email"].annotation is str
 
         # The optional parameter should have a default of None
         assert sig.parameters["data"].default is None
-        assert (
-            sig.parameters["data"].annotation
-            is Annotated[Optional[str], "The row to narrow down the search."]
-        )
+        assert sig.parameters["data"].annotation is Optional[str]
 
         # The optional parameter should have a default of None
         assert sig.parameters["id"].default is None
-        assert (
-            sig.parameters["id"].annotation
-            is Annotated[Optional[int], "The id to narrow down the search."]
-        )
+        assert sig.parameters["id"].annotation is Optional[int]
 
     async def test_run_tool_with_optional_params_omitted(self, toolbox: ToolboxClient):
         """Invoke a tool providing only the required parameter."""
@@ -404,27 +395,15 @@ class TestMapParams:
         sig = signature(tool)
 
         assert "execution_context" in sig.parameters
-        assert (
-            sig.parameters["execution_context"].annotation
-            == Annotated[
-                dict[str, Any],
-                "A flexible set of key-value pairs for the execution environment.",
-            ]
-        )
+        assert sig.parameters["execution_context"].annotation == dict[str, Any]
         assert sig.parameters["execution_context"].default is Parameter.empty
 
         assert "user_scores" in sig.parameters
-        assert (
-            sig.parameters["user_scores"].annotation
-            == Annotated[dict[str, int], "A map of user IDs to their scores."]
-        )
+        assert sig.parameters["user_scores"].annotation == dict[str, int]
         assert sig.parameters["user_scores"].default is Parameter.empty
 
         assert "feature_flags" in sig.parameters
-        assert (
-            sig.parameters["feature_flags"].annotation
-            == Annotated[Optional[dict[str, bool]], "Optional feature flags."]
-        )
+        assert sig.parameters["feature_flags"].annotation == Optional[dict[str, bool]]
         assert sig.parameters["feature_flags"].default is None
 
     async def test_run_tool_with_map_params(self, toolbox: ToolboxClient):

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -15,7 +15,7 @@
 
 import inspect
 from types import MappingProxyType
-from typing import Annotated, AsyncGenerator, Callable, Mapping
+from typing import AsyncGenerator, Callable, Mapping
 from unittest.mock import AsyncMock, Mock
 from warnings import catch_warnings, simplefilter
 
@@ -26,7 +26,7 @@ from aioresponses import aioresponses
 from pydantic import ValidationError
 
 from toolbox_core.protocol import ParameterSchema
-from toolbox_core.tool import ToolboxTool, resolve_value
+from toolbox_core.tool import ToolboxTool, create_func_docstring, resolve_value
 
 TEST_BASE_URL = "http://toolbox.example.com"
 HTTPS_BASE_URL = "https://toolbox.example.com"
@@ -124,6 +124,91 @@ def toolbox_tool(
     )
 
 
+def test_create_func_docstring_one_param_real_schema():
+    """
+    Tests create_func_docstring with one real ParameterSchema instance.
+    """
+    description = "This tool does one thing."
+    params = [
+        ParameterSchema(
+            name="input_file", type="string", description="Path to the input file."
+        )
+    ]
+
+    result_docstring = create_func_docstring(description, params)
+
+    expected_docstring = (
+        "This tool does one thing.\n\n"
+        "Args:\n"
+        "    input_file (str): Path to the input file."
+    )
+
+    assert result_docstring == expected_docstring
+
+
+def test_create_func_docstring_multiple_params_real_schema():
+    """
+    Tests create_func_docstring with multiple real ParameterSchema instances.
+    """
+    description = "This tool does multiple things."
+    params = [
+        ParameterSchema(name="query", type="string", description="The search query."),
+        ParameterSchema(
+            name="max_results", type="integer", description="Maximum results to return."
+        ),
+        ParameterSchema(
+            name="verbose", type="boolean", description="Enable verbose output."
+        ),
+    ]
+
+    result_docstring = create_func_docstring(description, params)
+
+    expected_docstring = (
+        "This tool does multiple things.\n\n"
+        "Args:\n"
+        "    query (str): The search query.\n"
+        "    max_results (int): Maximum results to return.\n"
+        "    verbose (bool): Enable verbose output."
+    )
+
+    assert result_docstring == expected_docstring
+
+
+def test_create_func_docstring_no_description_real_schema():
+    """
+    Tests create_func_docstring with empty description and one real ParameterSchema.
+    """
+    description = ""
+    params = [
+        ParameterSchema(
+            name="config_id", type="string", description="The ID of the configuration."
+        )
+    ]
+
+    result_docstring = create_func_docstring(description, params)
+
+    expected_docstring = (
+        "\n\nArgs:\n" "    config_id (str): The ID of the configuration."
+    )
+
+    assert result_docstring == expected_docstring
+    assert result_docstring.startswith("\n\nArgs:")
+    assert "config_id (str): The ID of the configuration." in result_docstring
+
+
+def test_create_func_docstring_no_params():
+    """
+    Tests create_func_docstring when the params list is empty.
+    """
+    description = "This is a tool description."
+    params = []
+
+    result_docstring = create_func_docstring(description, params)
+
+    assert result_docstring == description
+    assert "\n\nArgs:" not in result_docstring
+
+
 @pytest.mark.asyncio
 async def test_tool_creation_callable_and_run(
     http_session: ClientSession,
@@ -162,14 +247,8 @@ async def test_tool_creation_callable_and_run(
 
         assert "message" in tool_instance.__signature__.parameters
         assert "count" in tool_instance.__signature__.parameters
-        assert (
-            tool_instance.__signature__.parameters["message"].annotation
-            == Annotated[str, "A message to process"]
-        )
-        assert (
-            tool_instance.__signature__.parameters["count"].annotation
-            == Annotated[int, "A number"]
-        )
+        assert tool_instance.__signature__.parameters["message"].annotation == str
+        assert tool_instance.__signature__.parameters["count"].annotation == int
 
         actual_result = await tool_instance("hello world", 5)
 

--- a/packages/toolbox-core/tests/test_utils.py
+++ b/packages/toolbox-core/tests/test_utils.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ValidationError
 
 from toolbox_core.protocol import ParameterSchema
 from toolbox_core.utils import (
+    create_func_docstring,
     identify_auth_requirements,
     params_to_pydantic_model,
     resolve_value,
@@ -40,6 +41,46 @@ def create_param_mock(name: str, description: str, annotation: Type) -> Mock:
 
     param_mock.to_param.return_value = mock_param_info
     return param_mock
+
+
+def test_create_func_docstring_no_params():
+    """Test create_func_docstring with no parameters."""
+    description = "This is a tool description."
+    params = []
+    expected_docstring = "This is a tool description."
+    assert create_func_docstring(description, params) == expected_docstring
+
+
+def test_create_func_docstring_with_params():
+    """Test create_func_docstring with multiple parameters using mocks."""
+    description = "Tool description."
+    params = [
+        create_param_mock(
+            name="param1", description="First parameter.", annotation=str
+        ),
+        create_param_mock(name="count", description="A number.", annotation=int),
+    ]
+    expected_docstring = """Tool description.
+
+Args:
+    param1 (str): First parameter.
+    count (int): A number."""
+    assert create_func_docstring(description, params) == expected_docstring
+
+
+def test_create_func_docstring_empty_description():
+    """Test create_func_docstring with an empty description using mocks."""
+    description = ""
+    params = [
+        create_param_mock(
+            name="param1", description="First parameter.", annotation=str
+        ),
+    ]
+    expected_docstring = """
+
+Args:
+    param1 (str): First parameter."""
+    assert create_func_docstring(description, params) == expected_docstring
 
 
 def test_identify_auth_requirements_none_required():


### PR DESCRIPTION
Reverts googleapis/mcp-toolbox-sdk-python#371