### PR TITLE
chore: Update renovate config to disable updates for pillow for py3.9

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,5 +47,12 @@
         '.kokoro/**',
       ],
     },
+    {
+      "description": "Disable pillow updates for python <=3.9 in pyproject.toml",
+      "matchFileNames": ["**/pyproject.toml"],
+      "matchPackageNames": ["Pillow"],
+      "matchCurrentValue": "==11.3.0",
+      "enabled": false
+    }
   ],
 }

--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -50,7 +50,8 @@ test = [
     "pytest-asyncio==1.2.0",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
-    "Pillow==11.3.0",
+    "Pillow==11.3.0; python_version == '3.9'",
+    "Pillow==12.0.0; python_version >= '3.10'",
     "google-cloud-secret-manager==2.24.0",
     "google-cloud-storage==3.4.0",
 ]

--- a/packages/toolbox-llamaindex/pyproject.toml
+++ b/packages/toolbox-llamaindex/pyproject.toml
@@ -50,7 +50,8 @@ test = [
     "pytest-asyncio==1.2.0",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
-    "Pillow==11.3.0",
+    "Pillow==11.3.0; python_version == '3.9'",
+    "Pillow==12.0.0; python_version >= '3.10'",
     "google-cloud-secret-manager==2.24.0",
     "google-cloud-storage==3.4.0",
 ]


### PR DESCRIPTION
chore: Update renovate config to disable updates for pillow for py3.9

This PR adds conditional download to the pillow library dependency based on the python version. Pillow v12 is not supported in python3.9. It also updates renovate bot to disable updates to pillow for python3.9

The config has been locally verified using the Renovate NPM package