### PR TITLE
fix: add prTitle field

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,8 +30,9 @@
       matchManagers: [
         'regex',
       ],
-      branchName: 'auto-update/toolbox-server-v{{newValue}}',
-      commitMessageTopic: 'chore(deps): update MCP Toolbox server for integration tests to {{newValue}}',
+      "branchName": "auto-update/toolbox-server-v{{newValue}}",
+      "commitMessageTopic": "update MCP Toolbox server version in integration tests to v{{newValue}}",
+      "prTitle": "chore(deps): update mcp toolbox server for integration tests to v{{newValue}}",
       matchUpdateTypes: [
         'minor',
         'patch',


### PR DESCRIPTION
## Description
Fix the PR Title in the Renovate config (https://github.com/googleapis/mcp-toolbox-sdk-python/pull/414) for auto-update of toolbox version.

## Related issue(s)
See also https://github.com/googleapis/mcp-toolbox-sdk-python/pull/380