### PR TITLE
deps(toolbox-langchain): Update langchain-core version constraint

### DIFF
--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "toolbox-core==0.5.2",              # x-release-please-version
-    "langchain-core>=0.2.23,<1.0.0",
+    "langchain-core>=0.2.23,<2.0.0",
     "PyYAML>=6.0.1,<7.0.0",
     "pydantic>=2.7.0,<3.0.0",
     "aiohttp>=3.8.6,<4.0.0",


### PR DESCRIPTION
Fixes https://github.com/googleapis/mcp-toolbox-sdk-python/issues/410

Langchain [released v1](https://docs.langchain.com/oss/python/releases/langchain-v1), and the current package dependency constraints caused breaking while installing `toolbox-langchain` package.

This PR adjusts the constraints to accommodate for the LangChain v1 major release.