### PR TITLE
deps: Remove Python 3.9 support and require Python 3.10+

### DIFF
--- a/packages/toolbox-core/pyproject.toml
+++ b/packages/toolbox-core/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 readme = "README.md"
 description = "Python Base SDK for interacting with the Toolbox service"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -67,6 +66,6 @@ target-version = ['py39']
 profile = "black"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 disallow_incomplete_defs = true

--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 readme = "README.md"
 description = "Python SDK for interacting with the Toolbox service with LangChain"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -50,7 +49,6 @@ test = [
     "pytest-asyncio==1.2.0",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
-    "Pillow==11.3.0; python_version == '3.9'",
     "Pillow==12.0.0; python_version >= '3.10'",
     "google-cloud-secret-manager==2.24.0",
     "google-cloud-storage==3.4.0",
@@ -67,6 +65,6 @@ target-version = ['py39']
 profile = "black"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 disallow_incomplete_defs = true

--- a/packages/toolbox-llamaindex/pyproject.toml
+++ b/packages/toolbox-llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 readme = "README.md"
 description = "Python SDK for interacting with the Toolbox service with LlamaIndex"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Google LLC", email = "googleapis-packages@google.com"}
 ]
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -50,7 +49,6 @@ test = [
     "pytest-asyncio==1.2.0",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
-    "Pillow==11.3.0; python_version == '3.9'",
     "Pillow==12.0.0; python_version >= '3.10'",
     "google-cloud-secret-manager==2.24.0",
     "google-cloud-storage==3.4.0",
@@ -67,6 +65,6 @@ target-version = ['py39']
 profile = "black"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Overview

This PR removes support for Python 3.9 from our SDKs, making Python >= 3.10 the minimum required version. It modifies metadata across Toolbox Python SDK packages to reflect Python >= 3.10 as the minimum required version.

## Reasons

* Key libraries such as `isort` (https://github.com/googleapis/mcp-toolbox-sdk-python/pull/393) and `langchain-core` (https://github.com/googleapis/mcp-toolbox-sdk-python/pull/401) have been updated and now require Python 3.10 or newer. To incorporate these latest versions and their features, we must also update our supported Python version.
* Python 3.9 has officially reached its end-of-life (https://devguide.python.org/versions). Continuing to support it would pose a security risk as it no longer receives security updates from the Python community.

This update allows us to leverage modern Python features, maintain compatibility with the latest versions of our dependencies, and ensure the overall security of our SDKs.

> [!NOTE]
> We have already updated [CI/CD workflows](https://pantheon.corp.google.com/cloud-build/triggers?referrer=search&e=13802955&mods=logs_tg_staging&project=toolbox-testing-438616) to remove Python 3.9 testing.