### PR TITLE
chore(deps): pin llama-index-cli to resolve dependency conflict

### DIFF
--- a/packages/toolbox-llamaindex/requirements.txt
+++ b/packages/toolbox-llamaindex/requirements.txt
@@ -1,5 +1,6 @@
 -e ../toolbox-core
 llama-index==0.14.4
+llama-index-cli==0.5.3
 PyYAML==6.0.3
 pydantic==2.11.10
 aiohttp==3.13.0


### PR DESCRIPTION
This PR resolves a dependency [installation failure](https://screenshot.googleplex.com/5xh3HRnZxJo92CG) that occurs when upgrading `llama-index` to version `0.14.8` (https://github.com/googleapis/mcp-toolbox-sdk-python/pull/390).

#### Problem

The upgrade to `llama-index==0.14.8` introduced a conflict with one of its transitive dependencies, `llama-index-cli`. The error arises because:

*   `llama-index==0.14.8` requires `llama-index-core>=0.14.8`.
*   The older version of `llama-index-cli` that was being selected by the installer requires `llama-index-core<0.14.0`.

These two requirements are mutually exclusive, causing the installation to fail.

#### Solution

This PR addresses the conflict by explicitly pinning the transitive dependency to a newer, compatible version. By adding `llama-index-cli==0.5.3` to the `requirements.txt` file, we instruct the package manager to use a version of the CLI tool that has updated its own dependencies to be compatible with the newer `llama-index` ecosystem.