### PR TITLE
deps: Pin llama-index-embeddings-openai to 0.5.1

### DIFF
--- a/packages/toolbox-llamaindex/requirements.txt
+++ b/packages/toolbox-llamaindex/requirements.txt
@@ -1,6 +1,7 @@
 -e ../toolbox-core
 llama-index==0.14.4
 llama-index-cli==0.5.3
+llama-index-embeddings-openai==0.5.1
 PyYAML==6.0.3
 pydantic==2.11.10
 aiohttp==3.13.0


### PR DESCRIPTION
This PR pins the `llama-index-embeddings-openai` dependency to version `0.5.1`.

This change resolves dependency conflicts between older versions of `llama-index-embeddings-openai` and the latest versions of `llama-index` and `llama-index-cli`. (https://github.com/googleapis/mcp-toolbox-sdk-python/pull/390)

Full logs: https://pantheon.corp.google.com/cloud-build/builds;region=global/40ca72e5-8136-41a4-9562-00cc0e598e34?project=toolbox-testing-438616&e=13802955&mods=logs_tg_staging