### PR TITLE
deps: Switch from llama-index to llama-index-core

### DIFF
--- a/packages/toolbox-llamaindex/pyproject.toml
+++ b/packages/toolbox-llamaindex/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "toolbox-core==0.5.2",              # x-release-please-version
-    "llama-index>=0.12.0,<1.0.0",
+    "llama-index-core>=0.12.0,<1.0.0",
     "PyYAML>=6.0.1,<7.0.0",
     "pydantic>=2.8.0,<3.0.0",
     "aiohttp>=3.8.6,<4.0.0",

--- a/packages/toolbox-llamaindex/requirements.txt
+++ b/packages/toolbox-llamaindex/requirements.txt
@@ -1,7 +1,5 @@
 -e ../toolbox-core
-llama-index==0.14.4
-llama-index-cli==0.5.3
-llama-index-embeddings-openai==0.5.1
+llama-index-core==0.14.4
 PyYAML==6.0.3
 pydantic==2.11.10
 aiohttp==3.13.0


### PR DESCRIPTION
This PR migrates our dependency from `llama-index` to `llama-index-core`. 

The `llama-index` package was causing [unnecessary dependency conflicts](https://pantheon.corp.google.com/cloud-build/builds;region=global/c82f6f5b-aefe-44ea-a532-dd6846126d4f;step=0?e=13802955&mods=logs_tg_staging&project=toolbox-testing-438616) due to a large number of unused extra dependencies.

Since we are only utilizing the core functionalities, switching to `llama-index-core` makes our installation more lightweight and generic.