### PR TITLE
chore: drop support for python 3.9

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,13 +63,6 @@
         '.kokoro/**',
       ],
     },
-    {
-      "description": "Disable pillow updates for python <=3.9 in pyproject.toml",
-      "matchFileNames": ["**/pyproject.toml"],
-      "matchPackageNames": ["Pillow"],
-      "matchCurrentValue": "==11.3.0",
-      "enabled": false
-    }
   ],
   regexManagers: [
     {

--- a/packages/toolbox-core/pyproject.toml
+++ b/packages/toolbox-core/pyproject.toml
@@ -60,7 +60,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"

--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -59,7 +59,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"

--- a/packages/toolbox-llamaindex/pyproject.toml
+++ b/packages/toolbox-llamaindex/pyproject.toml
@@ -59,7 +59,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Removes support for Python 3.9 from the project.

- Updates pyproject.toml in all packages to target Python 3.10+ for Black.
- Removes Python 3.9 specific Renovate rules.