### PR TITLE
chore: fix initial version in manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,5 @@
   "packages/toolbox-langchain": "0.5.4",
   "packages/toolbox-core": "0.5.4",
   "packages/toolbox-llamaindex": "0.5.4",
-  "packages/toolbox-adk": ""
+  "packages/toolbox-adk": "0.0.1"
 }


### PR DESCRIPTION
This PR should fix the version parsing error while running release-please through a local CLI.