### PR TITLE
chore: Auto-update toolbox-core version dep in toolbox-adk

### DIFF
--- a/packages/toolbox-adk/pyproject.toml
+++ b/packages/toolbox-adk/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "toolbox-core>=0.5.4",
+    "toolbox-core==0.5.4",              # x-release-please-version
     "google-auth>=2.43.0,<3.0.0",
     "google-auth-oauthlib>=1.2.0,<2.0.0",
     "google-adk>=1.20.0,<2.0.0", 


### PR DESCRIPTION
Set the `toolbox-core` dependency in `toolbox-adk` package to auto-update through release-please.