### PR TITLE
ci: add pyproject.toml to release-please extra-files for toolbox-adk

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,6 +47,7 @@
     "packages/toolbox-adk": {
       "component": "toolbox-adk",
       "extra-files": [
+        "pyproject.toml",
         "src/toolbox_adk/version.py"
       ]
     }


### PR DESCRIPTION
This enables release please to auto-update `toolbox-core` dependency in `pyproject.toml` for `toolbox-adk`.