### PR TITLE
fix(adk): pin opentelemetry deps to resolve py3.10 pip timeout

### DIFF
--- a/packages/toolbox-adk/requirements.txt
+++ b/packages/toolbox-adk/requirements.txt
@@ -3,3 +3,7 @@ google-adk==1.20.0
 google-auth==2.45.0
 google-auth-oauthlib==1.2.1
 typing-extensions==4.12.2
+opentelemetry-exporter-otlp-proto-http==1.37.0
+opentelemetry-exporter-gcp-trace==1.9.0
+opentelemetry-exporter-gcp-monitoring==1.9.0a0
+opentelemetry-sdk==1.37.0


### PR DESCRIPTION
Updates `toolbox-adk` dependencies to explicitly pin `opentelemetry` exporter packages to match the `opentelemetry-sdk` version (1.37.0) enforced by `google-adk`.

This resolves a dependency resolution timeout (for example [here](https://pantheon.corp.google.com/cloud-build/builds/77c99bb4-86a4-4c27-b30b-727ecf00da9d?project=107716898620)) in Python 3.10 integration tests caused by `pip` backtracking endlessly when attempting to resolve conflicting versions of `opentelemetry-exporter-otlp-proto-http` against the pinned SDK.