### PR TITLE
fix(adk): Descope ToolboxContext class in favor of direct hook arguments

### DIFF
--- a/packages/toolbox-adk/README.md
+++ b/packages/toolbox-adk/README.md
@@ -217,21 +217,22 @@ You can attach `pre_hook` and `post_hook` functions to execute logic before and 
 > The `pre_hook` can modify `context.arguments` to dynamically alter the inputs passed to the tool.
 
 ```python
-from toolbox_adk import ToolboxContext
+from google.adk.tools.tool_context import ToolContext
+from typing import Any, Dict, Optional
 
-async def log_start(context: ToolboxContext):
-    print(f"Starting tool with args: {context.arguments}")
-    # context.tool_context is the underlying ADK ToolContext
+async def log_start(context: ToolContext, args: Dict[str, Any]):
+    print(f"Starting tool with args: {args}")
+    # context is the ADK ToolContext
     # Example: Inject or modify arguments
-    # context.arguments["user_id"] = "123"
+    # args["user_id"] = "123"
 
-async def log_end(context: ToolboxContext):
+async def log_end(context: ToolContext, args: Dict[str, Any], result: Optional[Any], error: Optional[Exception]):
     print("Finished tool execution")
     # Inspect result or error
-    if context.error:
-        print(f"Tool failed: {context.error}")
+    if error:
+        print(f"Tool failed: {error}")
     else:
-        print(f"Tool succeeded with result: {context.result}")
+        print(f"Tool succeeded with result: {result}")
 
 toolset = ToolboxToolset(
     server_url="...",

--- a/packages/toolbox-adk/src/toolbox_adk/__init__.py
+++ b/packages/toolbox-adk/src/toolbox_adk/__init__.py
@@ -14,7 +14,7 @@
 
 from .client import ToolboxClient
 from .credentials import CredentialConfig, CredentialStrategy, CredentialType
-from .tool import ToolboxContext, ToolboxTool
+from .tool import ToolboxTool
 from .toolset import ToolboxToolset
 from .version import __version__
 
@@ -24,6 +24,5 @@ __all__ = [
     "CredentialType",
     "ToolboxClient",
     "ToolboxTool",
-    "ToolboxContext",
     "ToolboxToolset",
 ]

--- a/packages/toolbox-adk/src/toolbox_adk/toolset.py
+++ b/packages/toolbox-adk/src/toolbox_adk/toolset.py
@@ -17,11 +17,12 @@ from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Unio
 from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.base_toolset import BaseToolset
+from google.adk.tools.tool_context import ToolContext
 from typing_extensions import override
 
 from .client import ToolboxClient
 from .credentials import CredentialConfig
-from .tool import ToolboxContext, ToolboxTool
+from .tool import ToolboxTool
 
 
 class ToolboxToolset(BaseToolset):
@@ -42,8 +43,15 @@ class ToolboxToolset(BaseToolset):
         auth_token_getters: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]]]]
         ] = None,
-        pre_hook: Optional[Callable[[ToolboxContext], Awaitable[None]]] = None,
-        post_hook: Optional[Callable[[ToolboxContext], Awaitable[None]]] = None,
+        pre_hook: Optional[
+            Callable[[ToolContext, Dict[str, Any]], Awaitable[None]]
+        ] = None,
+        post_hook: Optional[
+            Callable[
+                [ToolContext, Dict[str, Any], Optional[Any], Optional[Exception]],
+                Awaitable[None],
+            ]
+        ] = None,
         **kwargs: Any,
     ):
         """

--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -27,7 +27,7 @@ from google.adk.auth.auth_credential import (
 )
 from google.adk.tools.base_tool import BaseTool
 
-from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset, ToolboxContext
+from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset
 
 # Ensure TOOLBOX_VERSION is set for the fixture
 if "TOOLBOX_VERSION" not in os.environ:

--- a/packages/toolbox-adk/tests/unit/test_tool.py
+++ b/packages/toolbox-adk/tests/unit/test_tool.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from toolbox_adk.credentials import CredentialConfig, CredentialType
-from toolbox_adk.tool import ToolboxContext, ToolboxTool
+from toolbox_adk.tool import ToolboxTool
 
 
 class TestToolboxTool:
@@ -45,13 +45,13 @@ class TestToolboxTool:
         mock_core.__name__ = "hooked_tool"
         mock_core.__doc__ = "hooked description"
 
-        async def before(ctx: ToolboxContext):
-            ctx.arguments["arg"] += 1
+        async def before(ctx, args):
+            args["arg"] += 1
 
-        async def after(ctx: ToolboxContext):
-            assert ctx.result == "res"
+        async def after(ctx, args, result, error):
+            assert result == "res"
             # Verify we can see the modified arg
-            assert ctx.arguments["arg"] == 2
+            assert args["arg"] == 2
 
         tool = ToolboxTool(mock_core, pre_hook=before, post_hook=after)
 
@@ -66,7 +66,7 @@ class TestToolboxTool:
         mock_core.__name__ = "mock"
         mock_core.__doc__ = "mock"
 
-        async def failing_hook(ctx):
+        async def failing_hook(ctx, args):
             raise ValueError("Boom")
 
         tool = ToolboxTool(mock_core, pre_hook=failing_hook)
@@ -100,9 +100,9 @@ class TestToolboxTool:
 
         captured_error = None
 
-        async def after(ctx):
+        async def after(ctx, args, result, error):
             nonlocal captured_error
-            captured_error = ctx.error
+            captured_error = error
 
         tool = ToolboxTool(mock_core, post_hook=after)
 


### PR DESCRIPTION
## Overview
This simplifies the `ToolboxTool` hook interface by removing the `ToolboxContext` state container and using direct parameter passing instead.

## Rationale
This change simplifies the initial API surface for the `v0` launch by using standard ADK arguments rather than a custom context object. The `ToolboxContext` state management pattern may be reconsidered for introduction in a future release if more complex state sharing between hooks becomes necessary.