### PR TITLE
feat: enable Python 3.14 support

### DIFF
--- a/packages/toolbox-adk/integration.cloudbuild.yaml
+++ b/packages/toolbox-adk/integration.cloudbuild.yaml
@@ -17,7 +17,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-adk'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -31,7 +30,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-adk'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -42,7 +40,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-adk'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
       - TOOLBOX_URL=$_TOOLBOX_URL
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID

--- a/packages/toolbox-adk/requirements.txt
+++ b/packages/toolbox-adk/requirements.txt
@@ -2,7 +2,7 @@
 google-adk==1.20.0
 google-auth==2.45.0
 google-auth-oauthlib==1.2.1
-typing-extensions>=4.12.2
+typing-extensions==4.14.1
 opentelemetry-exporter-otlp-proto-http==1.37.0
 opentelemetry-exporter-gcp-trace==1.9.0
 opentelemetry-exporter-gcp-monitoring==1.9.0a0

--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -17,7 +17,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-core'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -31,7 +30,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-core'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -42,7 +40,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-core'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
       - TOOLBOX_URL=$_TOOLBOX_URL
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID

--- a/packages/toolbox-core/pyproject.toml
+++ b/packages/toolbox-core/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 dependencies = [
-    "pydantic>=2.12.0,<3.0.0",
+    "pydantic>=2.7.0,<3.0.0",
     "aiohttp>=3.8.6,<4.0.0",
     "deprecated>=1.2.15,<2.0.0",
     "google-auth>=2.0.0,<3.0.0",

--- a/packages/toolbox-langchain/integration.cloudbuild.yaml
+++ b/packages/toolbox-langchain/integration.cloudbuild.yaml
@@ -17,7 +17,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-langchain'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -31,7 +30,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-langchain'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -42,7 +40,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-langchain'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
       - TOOLBOX_URL=$_TOOLBOX_URL
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID

--- a/packages/toolbox-llamaindex/integration.cloudbuild.yaml
+++ b/packages/toolbox-llamaindex/integration.cloudbuild.yaml
@@ -17,7 +17,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-llamaindex'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -31,7 +30,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-llamaindex'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
     args:
       - '-c'
       - |
@@ -42,7 +40,6 @@ steps:
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-llamaindex'
     env:
-      - 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
       - TOOLBOX_URL=$_TOOLBOX_URL
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID


### PR DESCRIPTION
## Overview
This PR enables official support for [Python 3.14](https://www.python.org/downloads/release/python-3142/) across the entire SDK.

## Changes
* Added Python 3.14 classifiers to all package `pyproject.toml` files.
* Updated `toolbox-core` to require `pydantic>=2.12.0`, ensuring usage of a Python 3.14-compatible `pydantic-core` version.
* Added `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` to integration tests to allow PyO3-based extensions to run on the newer runtime.