### PR TITLE
fix(mcp): correctly propagate client headers during init

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -45,7 +45,9 @@ class _McpHttpTransportBase(ITransport, ABC):
         self._init_lock = asyncio.Lock()
         self._init_task: Optional[asyncio.Task] = None
 
-    async def _ensure_initialized(self, headers: Optional[Mapping[str, str]] = None) -> None:
+    async def _ensure_initialized(
+        self, headers: Optional[Mapping[str, str]] = None
+    ) -> None:
         """Ensures the session is initialized before making requests."""
         async with self._init_lock:
             if self._init_task is None:
@@ -124,6 +126,8 @@ class _McpHttpTransportBase(ITransport, ABC):
             await self._session.close()
 
     @abstractmethod
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
+    async def _initialize_session(
+        self, headers: Optional[Mapping[str, str]] = None
+    ) -> None:
         """Initializes the MCP session."""
         pass

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -45,7 +45,7 @@ class _McpHttpTransportBase(ITransport, ABC):
         self._init_lock = asyncio.Lock()
         self._init_task: Optional[asyncio.Task] = None
 
-    async def _ensure_initialized(self, headers: Optional[Mapping[str, str]] = None):
+    async def _ensure_initialized(self, headers: Optional[Mapping[str, str]] = None) -> None:
         """Ensures the session is initialized before making requests."""
         async with self._init_lock:
             if self._init_task is None:
@@ -124,6 +124,6 @@ class _McpHttpTransportBase(ITransport, ABC):
             await self._session.close()
 
     @abstractmethod
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
         """Initializes the MCP session."""
         pass

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -14,7 +14,7 @@
 
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Mapping, Optional
 
 from aiohttp import ClientSession
 
@@ -45,11 +45,13 @@ class _McpHttpTransportBase(ITransport, ABC):
         self._init_lock = asyncio.Lock()
         self._init_task: Optional[asyncio.Task] = None
 
-    async def _ensure_initialized(self):
+    async def _ensure_initialized(self, headers: Optional[Mapping[str, str]] = None):
         """Ensures the session is initialized before making requests."""
         async with self._init_lock:
             if self._init_task is None:
-                self._init_task = asyncio.create_task(self._initialize_session())
+                self._init_task = asyncio.create_task(
+                    self._initialize_session(headers=headers)
+                )
         await self._init_task
 
     @property
@@ -122,6 +124,6 @@ class _McpHttpTransportBase(ITransport, ABC):
             await self._session.close()
 
     @abstractmethod
-    async def _initialize_session(self):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
         """Initializes the MCP session."""
         pass

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -81,7 +81,7 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,
@@ -92,7 +92,9 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
         )
 
         result = await self._send_request(
-            url=self._mcp_base_url, request=types.InitializeRequest(params=params)
+            url=self._mcp_base_url,
+            request=types.InitializeRequest(params=params),
+            headers=headers,
         )
 
         self._server_version = result.serverInfo.version
@@ -106,7 +108,9 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
             raise RuntimeError("Server does not support the 'tools' capability.")
 
         await self._send_request(
-            url=self._mcp_base_url, request=types.InitializedNotification()
+            url=self._mcp_base_url,
+            request=types.InitializedNotification(),
+            headers=headers,
         )
 
     async def tools_list(
@@ -115,7 +119,7 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
         headers: Optional[Mapping[str, str]] = None,
     ) -> ManifestSchema:
         """Lists available tools from the server using the MCP protocol."""
-        await self._ensure_initialized()
+        await self._ensure_initialized(headers=headers)
 
         url = self._mcp_base_url + (toolset_name if toolset_name else "")
         result = await self._send_request(
@@ -151,7 +155,7 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
         self, tool_name: str, arguments: dict, headers: Optional[Mapping[str, str]]
     ) -> str:
         """Invokes a specific tool on the server using the MCP protocol."""
-        await self._ensure_initialized()
+        await self._ensure_initialized(headers=headers)
 
         result = await self._send_request(
             url=self._mcp_base_url,

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -81,7 +81,9 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
+    async def _initialize_session(
+        self, headers: Optional[Mapping[str, str]] = None
+    ) -> None:
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -81,7 +81,7 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,
@@ -96,6 +96,9 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
             request=types.InitializeRequest(params=params),
             headers=headers,
         )
+
+        if result is None:
+            raise RuntimeError("Failed to initialize session: No response from server.")
 
         self._server_version = result.serverInfo.version
         if result.protocolVersion != self._protocol_version:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -97,7 +97,9 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
+    async def _initialize_session(
+        self, headers: Optional[Mapping[str, str]] = None
+    ) -> None:
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -97,7 +97,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,
@@ -112,6 +112,9 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
             request=types.InitializeRequest(params=params),
             headers=headers,
         )
+
+        if result is None:
+            raise RuntimeError("Failed to initialize session: No response from server.")
 
         self._server_version = result.serverInfo.version
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -97,7 +97,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,
@@ -110,6 +110,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
         result = await self._send_request(
             url=self._mcp_base_url,
             request=types.InitializeRequest(params=params),
+            headers=headers,
         )
 
         self._server_version = result.serverInfo.version
@@ -138,6 +139,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
         await self._send_request(
             url=self._mcp_base_url,
             request=types.InitializedNotification(),
+            headers=headers,
         )
 
     async def tools_list(
@@ -146,7 +148,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
         headers: Optional[Mapping[str, str]] = None,
     ) -> ManifestSchema:
         """Lists available tools from the server using the MCP protocol."""
-        await self._ensure_initialized()
+        await self._ensure_initialized(headers=headers)
 
         url = self._mcp_base_url + (toolset_name if toolset_name else "")
         result = await self._send_request(
@@ -185,7 +187,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
         self, tool_name: str, arguments: dict, headers: Optional[Mapping[str, str]]
     ) -> str:
         """Invokes a specific tool on the server using the MCP protocol."""
-        await self._ensure_initialized()
+        await self._ensure_initialized(headers=headers)
 
         result = await self._send_request(
             url=self._mcp_base_url,

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -88,7 +88,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,
@@ -103,6 +103,9 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
             request=types.InitializeRequest(params=params),
             headers=headers,
         )
+
+        if result is None:
+            raise RuntimeError("Failed to initialize session: No response from server.")
 
         self._server_version = result.serverInfo.version
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -88,7 +88,9 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None) -> None:
+    async def _initialize_session(
+        self, headers: Optional[Mapping[str, str]] = None
+    ) -> None:
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -88,7 +88,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
                     raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
             return None
 
-    async def _initialize_session(self):
+    async def _initialize_session(self, headers: Optional[Mapping[str, str]] = None):
         """Initializes the MCP session."""
         params = types.InitializeRequestParams(
             protocolVersion=self._protocol_version,
@@ -101,6 +101,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
         result = await self._send_request(
             url=self._mcp_base_url,
             request=types.InitializeRequest(params=params),
+            headers=headers,
         )
 
         self._server_version = result.serverInfo.version
@@ -119,6 +120,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
         await self._send_request(
             url=self._mcp_base_url,
             request=types.InitializedNotification(),
+            headers=headers,
         )
 
     async def tools_list(
@@ -127,7 +129,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
         headers: Optional[Mapping[str, str]] = None,
     ) -> ManifestSchema:
         """Lists available tools from the server using the MCP protocol."""
-        await self._ensure_initialized()
+        await self._ensure_initialized(headers=headers)
 
         url = self._mcp_base_url + (toolset_name if toolset_name else "")
         result = await self._send_request(
@@ -166,7 +168,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
         self, tool_name: str, arguments: dict, headers: Optional[Mapping[str, str]]
     ) -> str:
         """Invokes a specific tool on the server using the MCP protocol."""
-        await self._ensure_initialized()
+        await self._ensure_initialized(headers=headers)
 
         result = await self._send_request(
             url=self._mcp_base_url,

--- a/packages/toolbox-core/tests/mcp_transport/test_base.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_base.py
@@ -27,7 +27,7 @@ from toolbox_core.protocol import ToolSchema
 class ConcreteTransport(_McpHttpTransportBase):
     """A concrete class for testing the abstract base class."""
 
-    async def _initialize_session(self):
+    async def _initialize_session(self, headers=None):
         pass
 
     async def _send_request(self, *args, **kwargs) -> Any:
@@ -95,7 +95,7 @@ class TestMcpHttpTransportBase:
         """Test the lock ensures initialization only happens once with concurrent calls."""
         init_started = asyncio.Event()
 
-        async def slow_init():
+        async def slow_init(*args, **kwargs):
             init_started.set()
             await asyncio.sleep(0.01)
 

--- a/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
+
+from toolbox_core.mcp_transport.v20250326 import types
 from toolbox_core.mcp_transport.v20250326.mcp import McpHttpTransportV20250326
 from toolbox_core.protocol import Protocol
-from toolbox_core.mcp_transport.v20250326 import types
+
 
 @pytest.mark.asyncio
 async def test_ensure_initialized_passes_headers():
@@ -24,13 +27,14 @@ async def test_ensure_initialized_passes_headers():
     transport = McpHttpTransportV20250326(
         "http://fake.com", session=mock_session, protocol=Protocol.MCP_v20250326
     )
-    
+
     transport._initialize_session = AsyncMock()
-    
+
     test_headers = {"X-Test": "123"}
     await transport._ensure_initialized(headers=test_headers)
-    
+
     transport._initialize_session.assert_called_with(headers=test_headers)
+
 
 @pytest.mark.asyncio
 async def test_initialize_passes_headers_to_request():
@@ -38,7 +42,7 @@ async def test_initialize_passes_headers_to_request():
     transport = McpHttpTransportV20250326(
         "http://fake.com", session=mock_session, protocol=Protocol.MCP_v20250326
     )
-    
+
     # Mock _send_request to simulate successful init
     transport._send_request = AsyncMock()
     transport._send_request.return_value = types.InitializeResult(
@@ -46,8 +50,8 @@ async def test_initialize_passes_headers_to_request():
         capabilities=types.ServerCapabilities(tools={"listChanged": True}),
         serverInfo=types.Implementation(name="test", version="1.0"),
     )
-    
-    # Mock session ID injection which happens in _send_request usually, 
+
+    # Mock session ID injection which happens in _send_request usually,
     # but here we just set it manually to satisfy the check
     transport._session_id = "test-session"
 
@@ -56,12 +60,12 @@ async def test_initialize_passes_headers_to_request():
 
     # Verify calls
     assert transport._send_request.call_count == 2
-    
+
     # First call: InitializeRequest
     init_call = transport._send_request.call_args_list[0]
     assert isinstance(init_call.kwargs["request"], types.InitializeRequest)
     assert init_call.kwargs["headers"] == test_headers
-    
+
     # Second call: InitializedNotification
     notify_call = transport._send_request.call_args_list[1]
     assert isinstance(notify_call.kwargs["request"], types.InitializedNotification)

--- a/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 from unittest.mock import AsyncMock
 from toolbox_core.mcp_transport.v20250326.mcp import McpHttpTransportV20250326

--- a/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
@@ -82,9 +82,7 @@ async def test_initialize_passes_headers_to_request(
     transport._send_request = AsyncMock()
     transport._send_request.return_value = types_module.InitializeResult(
         protocolVersion=protocol_version_str,
-        capabilities=types_module.ServerCapabilities(
-            tools={"listChanged": True}
-        ),
+        capabilities=types_module.ServerCapabilities(tools={"listChanged": True}),
         serverInfo=types_module.Implementation(name="test", version="1.0"),
     )
 

--- a/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_header_propagation.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import AsyncMock
+from toolbox_core.mcp_transport.v20250326.mcp import McpHttpTransportV20250326
+from toolbox_core.protocol import Protocol
+from toolbox_core.mcp_transport.v20250326 import types
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_passes_headers():
+    mock_session = AsyncMock()
+    transport = McpHttpTransportV20250326(
+        "http://fake.com", session=mock_session, protocol=Protocol.MCP_v20250326
+    )
+    
+    transport._initialize_session = AsyncMock()
+    
+    test_headers = {"X-Test": "123"}
+    await transport._ensure_initialized(headers=test_headers)
+    
+    transport._initialize_session.assert_called_with(headers=test_headers)
+
+@pytest.mark.asyncio
+async def test_initialize_passes_headers_to_request():
+    mock_session = AsyncMock()
+    transport = McpHttpTransportV20250326(
+        "http://fake.com", session=mock_session, protocol=Protocol.MCP_v20250326
+    )
+    
+    # Mock _send_request to simulate successful init
+    transport._send_request = AsyncMock()
+    transport._send_request.return_value = types.InitializeResult(
+        protocolVersion="2025-03-26",
+        capabilities=types.ServerCapabilities(tools={"listChanged": True}),
+        serverInfo=types.Implementation(name="test", version="1.0"),
+    )
+    
+    # Mock session ID injection which happens in _send_request usually, 
+    # but here we just set it manually to satisfy the check
+    transport._session_id = "test-session"
+
+    test_headers = {"Authorization": "Bearer token"}
+    await transport._initialize_session(headers=test_headers)
+
+    # Verify calls
+    assert transport._send_request.call_count == 2
+    
+    # First call: InitializeRequest
+    init_call = transport._send_request.call_args_list[0]
+    assert isinstance(init_call.kwargs["request"], types.InitializeRequest)
+    assert init_call.kwargs["headers"] == test_headers
+    
+    # Second call: InitializedNotification
+    notify_call = transport._send_request.call_args_list[1]
+    assert isinstance(notify_call.kwargs["request"], types.InitializedNotification)
+    assert notify_call.kwargs["headers"] == test_headers


### PR DESCRIPTION
Fixes https://github.com/googleapis/mcp-toolbox-sdk-python/issues/498.

Tested on cloud run instance