### PR TITLE
fix(adk): add missing @override decorator to close method

### DIFF
--- a/packages/toolbox-adk/src/toolbox_adk/toolset.py
+++ b/packages/toolbox-adk/src/toolbox_adk/toolset.py
@@ -138,6 +138,7 @@ class ToolboxToolset(BaseToolset):
             for t in tools
         ]
 
+    @override
     async def close(self):
         if self.__client:
             await self.__client.close()


### PR DESCRIPTION
Adds the `@override` decorator to `ToolboxToolset.close` to explicitly enforce that it overrides `BaseToolset.close`.

This improves static analysis safety by ensuring we are alerted if the base class signature changes or if the method is removed in the future.