### PR TITLE
chore: decouple release configuration for packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "release-type": "python",
+  "separate-pull-requests": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
@@ -51,17 +52,5 @@
         "src/toolbox_adk/version.py"
       ]
     }
-  },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "toolbox-python-sdks",
-      "components": [
-        "toolbox-core",
-        "toolbox-langchain",
-        "toolbox-llamaindex",
-        "toolbox-adk"
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Updates the `release-please` configuration to allow packages to be released independently of each other.

Future releases will track versions independently based on changes within each package's directory.

> [!NOTE]
> This change does *not* modify the current versions in `.release-please-manifest.json`, but subsequent releases will diverge.

For reference, here are the full `release-please` [dry run logs](https://paste.googleplex.com/6076690705022976).