### PR TITLE
chore(adk): add protocol parameter tests

### DIFF
--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -26,6 +26,7 @@ from google.adk.auth.auth_credential import (
     OAuth2Auth,
 )
 from google.adk.tools.base_tool import BaseTool
+from toolbox_core.protocol import Protocol
 
 from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset
 
@@ -64,6 +65,55 @@ class TestToolboxAdkIntegration:
             ctx = MagicMock()
             result = await tool.run_async({"id": "1"}, ctx)
 
+            assert "row1" in result
+
+        finally:
+            await toolset.close()
+
+    async def test_load_toolset_with_default_protocol(self):
+        """Test initializing toolset with default protocol (MCP)."""
+        toolset = ToolboxToolset(
+            server_url="http://localhost:5000",
+            toolset_name="my-toolset",
+            credentials=CredentialStrategy.toolbox_identity(),
+        )
+
+        try:
+            tools = await toolset.get_tools()
+            assert len(tools) > 0
+            
+            # Find 'get-row-by-id'
+            tool = next((t for t in tools if t.name == "get-row-by-id"), None)
+            assert tool is not None
+            
+            # Run it to ensure it actually works without the protocol
+            ctx = MagicMock()
+            result = await tool.run_async({"id": "1"}, ctx)
+            assert "row1" in result
+
+        finally:
+            await toolset.close()
+
+    async def test_load_toolset_with_explicit_protocol(self):
+        """Test initializing toolset with specific protocol (TOOLBOX)."""
+        toolset = ToolboxToolset(
+            server_url="http://localhost:5000",
+            toolset_name="my-toolset",
+            credentials=CredentialStrategy.toolbox_identity(),
+            protocol=Protocol.TOOLBOX,
+        )
+
+        try:
+            tools = await toolset.get_tools()
+            assert len(tools) > 0
+            
+            # Find 'get-row-by-id'
+            tool = next((t for t in tools if t.name == "get-row-by-id"), None)
+            assert tool is not None
+            
+            # Run it to ensure it actually works with the protocol
+            ctx = MagicMock()
+            result = await tool.run_async({"id": "1"}, ctx)
             assert "row1" in result
 
         finally:

--- a/packages/toolbox-adk/tests/unit/test_toolset.py
+++ b/packages/toolbox-adk/tests/unit/test_toolset.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from toolbox_core.protocol import Protocol
 
 from toolbox_adk.tool import ToolboxTool
 from toolbox_adk.toolset import ToolboxToolset
@@ -103,3 +105,15 @@ class TestToolboxToolset:
         _ = toolset.client
         await toolset.close()
         mock_instance.close.assert_awaited()
+
+    @patch("toolbox_adk.toolset.ToolboxClient")
+    def test_init_with_protocol(self, mock_client_cls):
+        """Test that protocol argument is passed to the client."""
+        toolset = ToolboxToolset("url", protocol=Protocol.MCP)
+        # Access client to trigger init
+        _ = toolset.client
+        
+        mock_client_cls.assert_called_once()
+        call_kwargs = mock_client_cls.call_args[1]
+        assert call_kwargs["protocol"] == Protocol.MCP
+


### PR DESCRIPTION
Adds both unit and integration tests to verify the support for the `protocol` parameter in `ToolboxToolset`.

This ensures that users can configure the transport protocol (e.g., for specific MCP versions) as documented in the `README`, with regression testing to guarantee it remains supported.