### PR TITLE
chore: add toolbox-adk to the top-level CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,6 @@ Changelogs
 | Package    | Version |
 | -------- | ------- |
 | [toolbox-core](https://github.com/googleapis/mcp-toolbox-sdk-python/tree/main/packages/toolbox-core/CHANGELOG.md)  | ![toolbox-core version](https://img.shields.io/pypi/v/toolbox-core.svg)    |
+| [toolbox-adk](https://github.com/googleapis/mcp-toolbox-sdk-python/tree/main/packages/toolbox-adk/CHANGELOG.md)  | ![toolbox-adk version](https://img.shields.io/pypi/v/toolbox-adk.svg)    |
 | [toolbox-langchain](https://github.com/googleapis/mcp-toolbox-sdk-python/tree/main/packages/toolbox-langchain/CHANGELOG.md) | ![toolbox-langchain version](https://img.shields.io/pypi/v/toolbox-langchain.svg)      |
 | [toolbox-llamaindex](https://github.com/googleapis/mcp-toolbox-sdk-python/tree/main/packages/toolbox-llamaindex/CHANGELOG.md)    | ![toolbox-llamaindex version](https://img.shields.io/pypi/v/toolbox-llamaindex.svg)    |


### PR DESCRIPTION
This adds `toolbox-adk` package (which was added recently) changelogs to the top-level `CHANGELOG.md`.