### PR TITLE
chore: Update Renovate config to dynamically match all packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,9 +68,7 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/packages/toolbox-core/integration.cloudbuild.yaml/',
-        '/packages/toolbox-langchain/integration.cloudbuild.yaml/',
-        '/packages/toolbox-llamaindex/integration.cloudbuild.yaml/',
+        'packages/*/integration.cloudbuild.yaml',
       ],
       matchStrings: [
         '_TOOLBOX_VERSION: [\'|"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)[\'|"]?',


### PR DESCRIPTION
### Description

This PR updates the `regexManagers` configuration in `.github/renovate.json5` to use a glob pattern for matching `integration.cloudbuild.yaml` files within the packages/ directory.

Using the glob pattern `packages/*/integration.cloudbuild.yaml` ensures that Renovate will automatically discover and process `integration.cloudbuild.yaml` files in any new package subdirectory created under `packages/`. This eliminates the need to manually add paths to the `renovate.json5` file each time a new package with a Cloud Build configuration is added, making the setup more scalable and less error-prone.

This addresses the suggestion made in PR #513 .