### PR TITLE
feat(adk)!: remove pre/post processing functionality

### DIFF
--- a/packages/toolbox-adk/README.md
+++ b/packages/toolbox-adk/README.md
@@ -25,7 +25,6 @@ It provides a seamless bridge between the `toolbox-core` SDK and the ADK's `Base
 - [Advanced Configuration](#advanced-configuration)
     - [Additional Headers](#additional-headers)
     - [Global Parameter Binding](#global-parameter-binding)
-    - [Usage with Hooks](#usage-with-hooks)
 
 ## Installation
 
@@ -256,38 +255,6 @@ toolset = ToolboxToolset(
         "region": "us-central1",
         "api_key": lambda: get_api_key() # Can be a callable
     }
-)
-```
-
-### Usage with Hooks
-
-You can attach `pre_hook` and `post_hook` functions to execute logic before and after every tool invocation.
-
-> [!NOTE]
-> The `pre_hook` can modify `context.arguments` to dynamically alter the inputs passed to the tool.
-
-```python
-from google.adk.tools import ToolContext
-from typing import Optional
-
-async def log_start(context: ToolContext, args: dict[str, any]) -> None:
-    print(f"Starting tool with args: {args}")
-    # context is the ADK ToolContext
-    # Example: Inject or modify arguments
-    # args["user_id"] = "123"
-
-async def log_end(context: ToolContext, args: Dict[str, Any], result: Optional[Any], error: Optional[Exception]):
-    print("Finished tool execution")
-    # Inspect result or error
-    if error:
-        print(f"Tool failed: {error}")
-    else:
-        print(f"Tool succeeded with result: {result}")
-
-toolset = ToolboxToolset(
-    server_url="...",
-    pre_hook=log_start,
-    post_hook=log_end
 )
 ```
 

--- a/packages/toolbox-adk/src/toolbox_adk/toolset.py
+++ b/packages/toolbox-adk/src/toolbox_adk/toolset.py
@@ -43,15 +43,6 @@ class ToolboxToolset(BaseToolset):
         auth_token_getters: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]]]]
         ] = None,
-        pre_hook: Optional[
-            Callable[[ToolContext, Dict[str, Any]], Awaitable[None]]
-        ] = None,
-        post_hook: Optional[
-            Callable[
-                [ToolContext, Dict[str, Any], Optional[Any], Optional[Exception]],
-                Awaitable[None],
-            ]
-        ] = None,
         **kwargs: Any,
     ):
         """
@@ -63,8 +54,6 @@ class ToolboxToolset(BaseToolset):
             additional_headers: Extra headers (static or dynamic).
             bound_params: Parameters to bind globally to loaded tools.
             auth_token_getters: Mapping of auth service names to token getters.
-            pre_hook: Hook to run before every tool execution.
-            post_hook: Hook to run after every tool execution.
         """
         super().__init__()
         self.__server_url = server_url
@@ -77,8 +66,6 @@ class ToolboxToolset(BaseToolset):
         self.__tool_names = tool_names
         self.__bound_params = bound_params
         self.__auth_token_getters = auth_token_getters
-        self.__pre_hook = pre_hook
-        self.__post_hook = post_hook
 
     @property
     def client(self) -> ToolboxClient:
@@ -131,8 +118,6 @@ class ToolboxToolset(BaseToolset):
         return [
             ToolboxTool(
                 core_tool=t,
-                pre_hook=self.__pre_hook,
-                post_hook=self.__post_hook,
                 auth_config=self.client.credential_config,
             )
             for t in tools

--- a/packages/toolbox-adk/tests/unit/test_toolset.py
+++ b/packages/toolbox-adk/tests/unit/test_toolset.py
@@ -81,21 +81,6 @@ class TestToolboxToolset:
 
     @patch("toolbox_adk.toolset.ToolboxClient")
     @pytest.mark.asyncio
-    async def test_hooks_propagation(self, mock_client_cls):
-        mock_client = mock_client_cls.return_value
-        t1 = MagicMock()
-        t1.__name__ = "tool1"
-        t1.__doc__ = "desc1"
-        mock_client.load_toolset = AsyncMock(return_value=[t1])
-
-        hook = AsyncMock()
-        toolset = ToolboxToolset("url", toolset_name="s", pre_hook=hook)
-
-        tools = await toolset.get_tools()
-        assert tools[0]._pre_hook == hook
-
-    @patch("toolbox_adk.toolset.ToolboxClient")
-    @pytest.mark.asyncio
     async def test_close(self, mock_client_cls):
         mock_instance = mock_client_cls.return_value
         mock_instance.close = AsyncMock()


### PR DESCRIPTION
This PR removes the `pre_hook` and `post_hook` capabilities from the `toolbox-adk` package to dedupe this feature since orchestrations have their own implementations in place, including ADK.

These tool execution hooks were previously available on `ToolboxTool` and `ToolboxToolset` to allow injecting custom logic before and after tool invocations. We are removing this feature to substantially simplify the codebase and to align the SDK with recent simplifications made across the MCP Toolbox and ADK documentation.