### PR TITLE
chore: optimize CI dependency resolution to prevent PyPI version conflicts

### DIFF
--- a/packages/toolbox-adk/integration.cloudbuild.yaml
+++ b/packages/toolbox-adk/integration.cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - id: Install library requirements
+  - id: Install requirements
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-adk'
     env:
@@ -24,17 +24,7 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        uv pip install -r requirements.txt
-    entrypoint: /bin/bash
-  - id: Install test requirements
-    name: 'python:${_VERSION}'
-    dir: 'packages/toolbox-adk'
-    env:
-    args:
-      - '-c'
-      - |
-        source /workspace/venv/bin/activate
-        uv pip install -e '.[test]'
+        uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests
     name: 'python:${_VERSION}'

--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - id: Install library requirements
+  - id: Install requirements
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-core'
     env:
@@ -24,17 +24,7 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        uv pip install -r requirements.txt
-    entrypoint: /bin/bash
-  - id: Install test requirements
-    name: 'python:${_VERSION}'
-    dir: 'packages/toolbox-core'
-    env:
-    args:
-      - '-c'
-      - |
-        source /workspace/venv/bin/activate
-        uv pip install -e '.[test]'
+        uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests
     name: 'python:${_VERSION}'

--- a/packages/toolbox-langchain/integration.cloudbuild.yaml
+++ b/packages/toolbox-langchain/integration.cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - id: Install library requirements
+  - id: Install requirements
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-langchain'
     env:
@@ -24,17 +24,7 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        uv pip install -r requirements.txt
-    entrypoint: /bin/bash
-  - id: Install test requirements
-    name: 'python:${_VERSION}'
-    dir: 'packages/toolbox-langchain'
-    env:
-    args:
-      - '-c'
-      - |
-        source /workspace/venv/bin/activate
-        uv pip install -e '.[test]'
+        uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests
     name: 'python:${_VERSION}'

--- a/packages/toolbox-llamaindex/integration.cloudbuild.yaml
+++ b/packages/toolbox-llamaindex/integration.cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  - id: Install library requirements
+  - id: Install requirements
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-llamaindex'
     env:
@@ -24,17 +24,7 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        uv pip install -r requirements.txt
-    entrypoint: /bin/bash
-  - id: Install test requirements
-    name: 'python:${_VERSION}'
-    dir: 'packages/toolbox-llamaindex'
-    env:
-    args:
-      - '-c'
-      - |
-        source /workspace/venv/bin/activate
-        uv pip install -e '.[test]'
+        uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests
     name: 'python:${_VERSION}'


### PR DESCRIPTION
This PR optimizes the Python SDK `integration.cloudbuild.yaml` pipelines by consolidating the dependency installation steps into a single `uv pip install` command.

Previously, the pipeline executed two sequential steps:

1. `uv pip install -r requirements.txt` (Installs local `toolbox-core` as an editable package)
1. `uv pip install -e '.[test]'` (Installs the SDK and its dependencies from `pyproject.toml`)

When Release Please bumped the local `toolbox-core` version, to `0.5.9` for instance, the second `uv` command evaluated the strict `toolbox-core==0.5.8` requirement in the downstream integrations `pyproject.toml` files. Detecting a mismatch against the local `0.5.9` editable install, `uv` uninstalled the local link and downloaded the older `.whl` from PyPI, causing unexpected `TypeError` regressions during tests (for instance becuase `client_name` arguments weren't present in `0.5.8`).

By passing both instructions to `uv` simultaneously, `uv`'s resolver correctly prioritizes the local path override in the `requirements.txt` specification and uses it to fulfill the `pyproject.toml` requirement simultaneously without trashing the environment or downloading old wheels. This also reduces overall CI overhead by eliminating a redundant step.