### PR TITLE
chore: Fix issue with release PR presubmits not picking latest changes from orch packages

### DIFF
--- a/packages/toolbox-adk/integration.cloudbuild.yaml
+++ b/packages/toolbox-adk/integration.cloudbuild.yaml
@@ -24,9 +24,10 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        # Dynamically pin toolbox-core to the local version to satisfy uv resolver with local code
-        CORE_VERSION=$(grep -oP '__version__ = "\K[^"]+' ../toolbox-core/src/toolbox_core/version.py)
-        sed -i "s/toolbox-core==[0-9.]*/toolbox-core==$CORE_VERSION/g" pyproject.toml
+        # Dynamically pin toolbox-core to the local version using Python exec to avoid importing missing dependencies
+        # Use $$ to escape shell variable for Cloud Build
+        CORE_VERSION=$$(python -c "v={}; exec(open('../toolbox-core/src/toolbox_core/version.py').read(), v); print(v['__version__'])")
+        sed -i "s/toolbox-core==[0-9.]*/toolbox-core==$$CORE_VERSION/g" pyproject.toml
         uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests

--- a/packages/toolbox-langchain/integration.cloudbuild.yaml
+++ b/packages/toolbox-langchain/integration.cloudbuild.yaml
@@ -24,9 +24,10 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        # Dynamically pin toolbox-core to the local version to satisfy uv resolver with local code
-        CORE_VERSION=$(grep -oP '__version__ = "\K[^"]+' ../toolbox-core/src/toolbox_core/version.py)
-        sed -i "s/toolbox-core==[0-9.]*/toolbox-core==$CORE_VERSION/g" pyproject.toml
+        # Dynamically pin toolbox-core to the local version using Python exec to avoid importing missing dependencies
+        # Use $$ to escape shell variable for Cloud Build
+        CORE_VERSION=$$(python -c "v={}; exec(open('../toolbox-core/src/toolbox_core/version.py').read(), v); print(v['__version__'])")
+        sed -i "s/toolbox-core==[0-9.]*/toolbox-core==$$CORE_VERSION/g" pyproject.toml
         uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests

--- a/packages/toolbox-llamaindex/integration.cloudbuild.yaml
+++ b/packages/toolbox-llamaindex/integration.cloudbuild.yaml
@@ -24,9 +24,10 @@ steps:
         uv venv /workspace/venv
         source /workspace/venv/bin/activate
         uv pip install uv
-        # Dynamically pin toolbox-core to the local version to satisfy uv resolver with local code
-        CORE_VERSION=$(grep -oP '__version__ = "\K[^"]+' ../toolbox-core/src/toolbox_core/version.py)
-        sed -i "s/toolbox-core==[0-9.]*/toolbox-core==$CORE_VERSION/g" pyproject.toml
+        # Dynamically pin toolbox-core to the local version using Python exec to avoid importing missing dependencies
+        # Use $$ to escape shell variable for Cloud Build
+        CORE_VERSION=$$(python -c "v={}; exec(open('../toolbox-core/src/toolbox_core/version.py').read(), v); print(v['__version__'])")
+        sed -i "s/toolbox-core==[0-9.]*/toolbox-core==$$CORE_VERSION/g" pyproject.toml
         uv pip install -r requirements.txt -e '.[test]'
     entrypoint: /bin/bash
   - id: Run integration tests


### PR DESCRIPTION
This PR continues changes from https://github.com/googleapis/mcp-toolbox-sdk-python/pull/546.

This PR applies dynamic version pinning to `toolbox-adk`, `toolbox-langchain`, and `toolbox-llamaindex` build configs. This ensures CI validation runs against the exact code version present in the PR, satisfying strict `uv` pinning without modifying `pyproject.toml` source