### PR TITLE
feat(adk): Enable support for ADK `v2.x`

### DIFF
--- a/packages/toolbox-adk/pyproject.toml
+++ b/packages/toolbox-adk/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "toolbox-core==0.5.10",
     "google-auth>=2.43.0,<3.0.0",
     "google-auth-oauthlib>=1.2.0,<2.0.0",
-    "google-adk>=1.20.0,<2.0.0", 
+    "google-adk>=1.20.0,<3.0.0", 
     "typing-extensions>=4.0.0"
 ]
 


### PR DESCRIPTION
This PR enables installing `toolbox-adk` package alongside ADK `v2.x`.