### PR TITLE
ci: harden lint workflows against credential exposure in fork PRs

### DIFF
--- a/.github/workflows/lint-toolbox-adk.yaml
+++ b/.github/workflows/lint-toolbox-adk.yaml
@@ -25,23 +25,14 @@ on:
 permissions: read-all
 
 jobs:
-  lint:
-    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
-    name: lint
+  remove-label:
+    if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    defaults:
-      run:
-        working-directory: ./packages/toolbox-adk
     permissions:
-      contents: 'read'
       issues: 'write'
       pull-requests: 'write'
     steps:
       - name: Remove PR Label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,12 +47,26 @@ jobs:
             } catch (e) {
               console.log('Failed to remove label. Another job may have already removed it!');
             }
+
+  lint:
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
+    name: lint
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: ./packages/toolbox-adk
+    permissions:
+      contents: 'read'
+    steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/lint-toolbox-core.yaml
+++ b/.github/workflows/lint-toolbox-core.yaml
@@ -25,23 +25,14 @@ on:
 permissions: read-all
 
 jobs:
-  lint:
-    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
-    name: lint
+  remove-label:
+    if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    defaults:
-      run:
-        working-directory: ./packages/toolbox-core
     permissions:
-      contents: 'read'
       issues: 'write'
       pull-requests: 'write'
     steps:
       - name: Remove PR Label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,12 +47,26 @@ jobs:
             } catch (e) {
               console.log('Failed to remove label. Another job may have already removed it!');
             }
+
+  lint:
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
+    name: lint
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: ./packages/toolbox-core
+    permissions:
+      contents: 'read'
+    steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/lint-toolbox-langchain.yaml
+++ b/.github/workflows/lint-toolbox-langchain.yaml
@@ -25,23 +25,14 @@ on:
 permissions: read-all
 
 jobs:
-  lint:
-    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
-    name: lint
+  remove-label:
+    if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    defaults:
-      run:
-        working-directory: ./packages/toolbox-langchain
     permissions:
-      contents: 'read'
       issues: 'write'
       pull-requests: 'write'
     steps:
       - name: Remove PR Label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,12 +47,26 @@ jobs:
             } catch (e) {
               console.log('Failed to remove label. Another job may have already removed it!');
             }
+
+  lint:
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
+    name: lint
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: ./packages/toolbox-langchain
+    permissions:
+      contents: 'read'
+    steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/lint-toolbox-llamaindex.yaml
+++ b/.github/workflows/lint-toolbox-llamaindex.yaml
@@ -25,23 +25,14 @@ on:
 permissions: read-all
 
 jobs:
-  lint:
-    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
-    name: lint
+  remove-label:
+    if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    defaults:
-      run:
-        working-directory: ./packages/toolbox-llamaindex
     permissions:
-      contents: 'read'
       issues: 'write'
       pull-requests: 'write'
     steps:
       - name: Remove PR Label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,12 +47,26 @@ jobs:
             } catch (e) {
               console.log('Failed to remove label. Another job may have already removed it!');
             }
+
+  lint:
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
+    name: lint
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: ./packages/toolbox-llamaindex
+    permissions:
+      contents: 'read'
+    steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
## Summary

The four lint workflows (`lint-toolbox-core`, `lint-toolbox-adk`, `lint-toolbox-langchain`, `lint-toolbox-llamaindex`) currently run the label-removal step and the lint steps in a single job. This means the lint steps — which check out and execute fork PR code (`pip install -r requirements.txt`, `pip install .[test]`) — run with `pull-requests: write` and `issues: write` permissions that are only needed by the label-removal step.

This PR splits each workflow into two jobs:

- **`remove-label`**: has write permissions, does NOT check out or execute any PR code
- **`lint`**: checks out and runs PR code, but only has `contents: read` permission

Also adds `persist-credentials: false` to the checkout step so the `GITHUB_TOKEN` is not stored in `~/.git-credentials` where subsequent steps could read it.

This follows the same hardening pattern applied to `googleapis/genai-toolbox` in commits `949e8242` and `3f83c497`.

## Reference

- [GitHub Security Lab: Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)