### PR TITLE
docs: rebrand references for repo and docsite

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,7 +59,7 @@ body:
       value: |
         1. OS type and version: (output of `uname -a`)
         2. How are you running Toolbox: 
-          - As a downloaded binary (e.g. from `curl -O https://storage.googleapis.com/mcp-toolbox/v$VERSION/linux/amd64/toolbox`)
+          - As a downloaded binary (e.g. from `curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/linux/amd64/toolbox`)
           - As a container (e.g. from `us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:$VERSION`)
           - Compiled from source (include the command used to build)
         3. Python version (output of `python --version`)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
         Please run through the following list and make sure you've tried the usual "quick fixes":
         - Search the [current open issues](https://github.com/googleapis/mcp-toolbox-sdk-python/issues)
         - Update to the [latest version of
-        Toolbox](https://github.com/googleapis/genai-toolbox/releases)
+        Toolbox](https://github.com/googleapis/mcp-toolbox/releases)
         - Update to the [latest version of the SDK](https://github.com/googleapis/mcp-toolbox-sdk-python/CHANGELOG.md).
       options: 
         - label: "I've searched the current open issues"
@@ -59,7 +59,7 @@ body:
       value: |
         1. OS type and version: (output of `uname -a`)
         2. How are you running Toolbox: 
-          - As a downloaded binary (e.g. from `curl -O https://storage.googleapis.com/genai-toolbox/v$VERSION/linux/amd64/toolbox`)
+          - As a downloaded binary (e.g. from `curl -O https://storage.googleapis.com/mcp-toolbox/v$VERSION/linux/amd64/toolbox`)
           - As a container (e.g. from `us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:$VERSION`)
           - Compiled from source (include the command used to build)
         3. Python version (output of `python --version`)

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,9 +24,9 @@
       pinDigests: true,
     },
     {
-      description: 'Auto-update genai-toolbox server version',
+      description: 'Auto-update mcp-toolbox server version',
       matchPackageNames: [
-        'googleapis/genai-toolbox',
+        'googleapis/mcp-toolbox',
       ],
       matchManagers: [
         'custom.regex',
@@ -74,9 +74,9 @@
         '_TOOLBOX_VERSION: [\'|"]?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)[\'|"]?',
       ],
       datasourceTemplate: 'github-releases',
-      depNameTemplate: 'googleapis/genai-toolbox',
+      depNameTemplate: 'googleapis/mcp-toolbox',
       versioningTemplate: 'semver',
-      packageNameTemplate: 'googleapis/genai-toolbox',
+      packageNameTemplate: 'googleapis/mcp-toolbox',
     },
   ],
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![MCP Toolbox
-Logo](https://raw.githubusercontent.com/googleapis/genai-toolbox/main/logo.png)
+Logo](https://raw.githubusercontent.com/googleapis/mcp-toolbox/main/logo.png)
 # MCP Toolbox SDKs for Python
 
 [![License: Apache
@@ -9,7 +9,7 @@ Version](https://img.shields.io/pypi/pyversions/toolbox-core)](https://pypi.org/
 
 This repository contains Python SDKs designed to seamlessly integrate the
 functionalities of the [MCP
-Toolbox](https://github.com/googleapis/genai-toolbox) into your Gen AI
+Toolbox](https://github.com/googleapis/mcp-toolbox) into your Gen AI
 applications. These SDKs allow you to load tools defined in Toolbox and use them
 as standard Python functions or objects within popular orchestration frameworks
 or your custom code.
@@ -72,13 +72,13 @@ to get started.
 ## License
 
 This project is licensed under the Apache License 2.0. See the
-[LICENSE](https://github.com/googleapis/genai-toolbox/blob/main/LICENSE) file
+[LICENSE](https://github.com/googleapis/mcp-toolbox/blob/main/LICENSE) file
 for details.
 
 ## Support
 
 If you encounter issues or have questions, please check the existing [GitHub
-Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox
+Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox
 project. If your issue is specific to one of the SDKs, please look for existing
 issues [here](https://github.com/googleapis/mcp-toolbox-sdk-python/issues) or
 open a new issue in this repository.

--- a/packages/toolbox-adk/README.md
+++ b/packages/toolbox-adk/README.md
@@ -1,8 +1,8 @@
-![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/genai-toolbox/main/logo.png)
+![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/mcp-toolbox/main/logo.png)
 
 # MCP Toolbox SDK for ADK
 
-This package allows Google ADK (Agent Development Kit) agents to natively use tools from the [MCP Toolbox](https://github.com/googleapis/genai-toolbox).
+This package allows Google ADK (Agent Development Kit) agents to natively use tools from the [MCP Toolbox](https://github.com/googleapis/mcp-toolbox).
 
 For detailed guides, authentication examples, and advanced configuration, visit the [Python SDK ADK Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/adk/).
 

--- a/packages/toolbox-adk/tests/integration/conftest.py
+++ b/packages/toolbox-adk/tests/integration/conftest.py
@@ -151,7 +151,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
 
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("genai-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox", source_blob_name, "toolbox")
 
     print("Toolbox binary downloaded successfully.")
     try:

--- a/packages/toolbox-adk/tests/integration/conftest.py
+++ b/packages/toolbox-adk/tests/integration/conftest.py
@@ -151,7 +151,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
 
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("mcp-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox-for-databases", source_blob_name, "toolbox")
 
     print("Toolbox binary downloaded successfully.")
     try:

--- a/packages/toolbox-core/DEVELOPER.md
+++ b/packages/toolbox-core/DEVELOPER.md
@@ -154,7 +154,7 @@ This project uses `release-please` for automated releases.
 ## Support
 
 If you encounter issues or have questions, please check the existing [GitHub
-Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox
+Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox
 project. If your issue is specific to one of the SDKs, please look for existing
 issues [here](https://github.com/googleapis/mcp-toolbox-sdk-python/issues) or
 open a new issue in this repository.

--- a/packages/toolbox-core/README.md
+++ b/packages/toolbox-core/README.md
@@ -1,12 +1,12 @@
-![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/genai-toolbox/main/logo.png)
+![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/mcp-toolbox/main/logo.png)
 
 # MCP Toolbox Core SDK
 
-[![PyPI version](https://badge.fury.io/py/toolbox-core.svg)](https://badge.fury.io/py/toolbox-core) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/toolbox-core)](https://pypi.org/project/toolbox-core/) [![Coverage Status](https://coveralls.io/repos/github/googleapis/genai-toolbox/badge.svg?branch=main)](https://coveralls.io/github/googleapis/genai-toolbox?branch=main)
+[![PyPI version](https://badge.fury.io/py/toolbox-core.svg)](https://badge.fury.io/py/toolbox-core) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/toolbox-core)](https://pypi.org/project/toolbox-core/) [![Coverage Status](https://coveralls.io/repos/github/googleapis/mcp-toolbox/badge.svg?branch=main)](https://coveralls.io/github/googleapis/mcp-toolbox?branch=main)
  [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This SDK allows you to seamlessly integrate the functionalities of
-[MCP Toolbox](https://github.com/googleapis/genai-toolbox) allowing you to load and
+[MCP Toolbox](https://github.com/googleapis/mcp-toolbox) allowing you to load and
 use tools defined in the service as standard Python functions within your GenAI
 applications.
 
@@ -72,8 +72,8 @@ Contributions are welcome! Please refer to the [`DEVELOPER.md`](https://github.c
 # License
 
 This project is licensed under the Apache License 2.0. See the
-[LICENSE](https://github.com/googleapis/genai-toolbox/blob/main/LICENSE) file for details.
+[LICENSE](https://github.com/googleapis/mcp-toolbox/blob/main/LICENSE) file for details.
 
 # Support
 
-If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox project.
+If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox project.

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -136,7 +136,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("genai-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox", source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -136,7 +136,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("mcp-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox-for-databases", source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")

--- a/packages/toolbox-langchain/DEVELOPER.md
+++ b/packages/toolbox-langchain/DEVELOPER.md
@@ -157,7 +157,7 @@ This project uses `release-please` for automated releases.
 ## Support
 
 If you encounter issues or have questions, please check the existing [GitHub
-Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox
+Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox
 project. If your issue is specific to one of the SDKs, please look for existing
 issues [here](https://github.com/googleapis/mcp-toolbox-sdk-python/issues) or
 open a new issue in this repository.

--- a/packages/toolbox-langchain/README.md
+++ b/packages/toolbox-langchain/README.md
@@ -1,8 +1,8 @@
-![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/genai-toolbox/main/logo.png)
+![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/mcp-toolbox/main/logo.png)
 # MCP Toolbox LangChain SDK
 
 This SDK allows you to seamlessly integrate the functionalities of
-[MCP Toolbox](https://github.com/googleapis/genai-toolbox) into your LangChain GenAI
+[MCP Toolbox](https://github.com/googleapis/mcp-toolbox) into your LangChain GenAI
 applications, enabling advanced orchestration and interaction with LLMs.
 
 For detailed guides, authentication examples, and advanced configuration, visit the [Python SDK Langchain Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/langchain/).
@@ -74,8 +74,8 @@ Contributions are welcome! Please refer to the [`DEVELOPER.md`](https://github.c
 # License
 
 This project is licensed under the Apache License 2.0. See the
-[LICENSE](https://github.com/googleapis/genai-toolbox/blob/main/LICENSE) file for details.
+[LICENSE](https://github.com/googleapis/mcp-toolbox/blob/main/LICENSE) file for details.
 
 # Support
 
-If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox project.
+If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox project.

--- a/packages/toolbox-langchain/tests/conftest.py
+++ b/packages/toolbox-langchain/tests/conftest.py
@@ -136,7 +136,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("genai-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox", source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")

--- a/packages/toolbox-langchain/tests/conftest.py
+++ b/packages/toolbox-langchain/tests/conftest.py
@@ -136,7 +136,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("mcp-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox-for-databases", source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")

--- a/packages/toolbox-llamaindex/DEVELOPER.md
+++ b/packages/toolbox-llamaindex/DEVELOPER.md
@@ -157,7 +157,7 @@ This project uses `release-please` for automated releases.
 ## Support
 
 If you encounter issues or have questions, please check the existing [GitHub
-Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox
+Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox
 project. If your issue is specific to one of the SDKs, please look for existing
 issues [here](https://github.com/googleapis/mcp-toolbox-sdk-python/issues) or
 open a new issue in this repository.

--- a/packages/toolbox-llamaindex/README.md
+++ b/packages/toolbox-llamaindex/README.md
@@ -1,8 +1,8 @@
-![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/genai-toolbox/main/logo.png)
+![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/mcp-toolbox/main/logo.png)
 # MCP Toolbox LlamaIndex SDK
 
 This SDK allows you to seamlessly integrate the functionalities of
-[MCP Toolbox](https://github.com/googleapis/genai-toolbox) into your LlamaIndex LLM
+[MCP Toolbox](https://github.com/googleapis/mcp-toolbox) into your LlamaIndex LLM
 applications, enabling advanced orchestration and interaction with GenAI models.
 
 For detailed guides, authentication examples, and advanced configuration, visit the [Python SDK LlamaIndex Guide](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/).
@@ -80,8 +80,8 @@ Contributions are welcome! Please refer to the [`DEVELOPER.md`](https://github.c
 # License
 
 This project is licensed under the Apache License 2.0. See the
-[LICENSE](https://github.com/googleapis/genai-toolbox/blob/main/LICENSE) file for details.
+[LICENSE](https://github.com/googleapis/mcp-toolbox/blob/main/LICENSE) file for details.
 
 # Support
 
-If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox project.
+If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/mcp-toolbox/issues) for the main Toolbox project.

--- a/packages/toolbox-llamaindex/tests/conftest.py
+++ b/packages/toolbox-llamaindex/tests/conftest.py
@@ -136,7 +136,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("genai-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox", source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")

--- a/packages/toolbox-llamaindex/tests/conftest.py
+++ b/packages/toolbox-llamaindex/tests/conftest.py
@@ -136,7 +136,7 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
     source_blob_name = get_toolbox_binary_url(toolbox_version)
-    download_blob("mcp-toolbox", source_blob_name, "toolbox")
+    download_blob("mcp-toolbox-for-databases", source_blob_name, "toolbox")
     print("Toolbox binary downloaded successfully.")
     try:
         print("Opening toolbox server process...")


### PR DESCRIPTION
## Overview

This PR updates legacy artifact repository links, CI configurations, and doc links to use the correct brand and URLs to prevent pipeline breakage or user friction.

## Changes

* Redirected legacy main project links (`genai-toolbox`) to `mcp-toolbox` across the root `README.md`, `CONTRIBUTING` guidance, and module-level directories.
* Standardized the `download_blob()` test fixtures inside `tests/conftest.py` of all packages to pull binary releases exclusively from the updated `mcp-toolbox` bucket.
* Updated `.github/renovate.json5` extraction regex configurations and `.github` bug templates to align dependencies onto the new nomenclature.