### PR TITLE
fix(core): add 'number' schema type mapping to fix float parameter loading

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -68,6 +68,7 @@ class Protocol(str, Enum):
 __TYPE_MAP = {
     "string": str,
     "integer": int,
+    "number": float,
     "float": float,
     "boolean": bool,
 }

--- a/packages/toolbox-core/tests/test_protocol.py
+++ b/packages/toolbox-core/tests/test_protocol.py
@@ -99,6 +99,20 @@ def test_parameter_schema_float():
     assert param.default == Parameter.empty
 
 
+def test_parameter_schema_number():
+    """Tests ParameterSchema with standard MCP type 'number'."""
+    schema = ParameterSchema(name="price", type="number", description="The item price")
+    expected_type = float
+    assert schema._ParameterSchema__get_type() == expected_type
+
+    param = schema.to_param()
+    assert isinstance(param, Parameter)
+    assert param.name == "price"
+    assert param.annotation == expected_type
+    assert param.kind == Parameter.POSITIONAL_OR_KEYWORD
+    assert param.default == Parameter.empty
+
+
 def test_parameter_schema_boolean():
     """Tests ParameterSchema with type 'boolean'."""
     schema = ParameterSchema(


### PR DESCRIPTION
## Description

This PR adds support for the standard JSON Schema `"number"` type.

## Context

Following the server's correction to emit standard `"type": "number"` for floating-point parameters in MCP manifests, the client failed to load any tools containing float parameters.

## Changes

* Maps the standard `"number"` type to Python's built-in `float` type.
* Retains the `"float"` mapping for backward compatibility with any legacy tool configs.
* Adds a comprehensive replication unit test.

## Checklist

- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [ ] Appropriate docs were updated (N/A - Docs are already correct)
- [ ] Make sure to add `!` if this involves a breaking change (N/A - Backward-compatible fix)

## Issue Reference

Fixes https://github.com/googleapis/mcp-toolbox-sdk-python/issues/649 🦕
