### PR TITLE
test(ci): [TMP] use patched toolbox:fix-meta image in integration tests

### DIFF
--- a/packages/toolbox-adk/integration.cloudbuild.yaml
+++ b/packages/toolbox-adk/integration.cloudbuild.yaml
@@ -31,6 +31,16 @@ steps:
         uv pip install -r requirements.txt
         uv pip install -e '.[test]'
     entrypoint: /bin/bash
+  - id: Extract patched server binary
+    name: 'gcr.io/cloud-builders/docker'
+    dir: 'packages/toolbox-adk'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker create --name temp_toolbox us-central1-docker.pkg.dev/database-toolbox/toolbox-dev/toolbox:fix-meta
+        docker cp temp_toolbox:/toolbox ./toolbox
+        docker rm temp_toolbox
   - id: Run integration tests
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-adk'
@@ -39,6 +49,7 @@ steps:
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID
       - TOOLBOX_MANIFEST_VERSION=${_TOOLBOX_MANIFEST_VERSION}
+      - TOOLBOX_SKIP_DOWNLOAD=true
     args:
       - '-c'
       - |

--- a/packages/toolbox-adk/tests/integration/conftest.py
+++ b/packages/toolbox-adk/tests/integration/conftest.py
@@ -60,6 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+        print(f"Skipping download. Using existing file {destination_file_name}")
+        return
     storage_client = storage.Client()
 
     bucket = storage_client.bucket(bucket_name)

--- a/packages/toolbox-adk/tests/integration/conftest.py
+++ b/packages/toolbox-adk/tests/integration/conftest.py
@@ -60,7 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
-    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(
+        destination_file_name
+    ):
         print(f"Skipping download. Using existing file {destination_file_name}")
         return
     storage_client = storage.Client()

--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -27,6 +27,16 @@ steps:
         uv pip install -e '.[test]'
         uv pip install -r requirements.txt
     entrypoint: /bin/bash
+  - id: Extract patched server binary
+    name: 'gcr.io/cloud-builders/docker'
+    dir: 'packages/toolbox-core'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker create --name temp_toolbox us-central1-docker.pkg.dev/database-toolbox/toolbox-dev/toolbox:fix-meta
+        docker cp temp_toolbox:/toolbox ./toolbox
+        docker rm temp_toolbox
   - id: Run integration tests
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-core'
@@ -35,6 +45,7 @@ steps:
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID
       - TOOLBOX_MANIFEST_VERSION=${_TOOLBOX_MANIFEST_VERSION}
+      - TOOLBOX_SKIP_DOWNLOAD=true
     args:
       - '-c'
       - |

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -60,6 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+        print(f"Skipping download. Using existing file {destination_file_name}")
+        return
     storage_client = storage.Client()
 
     bucket = storage_client.bucket(bucket_name)

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -60,7 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
-    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(
+        destination_file_name
+    ):
         print(f"Skipping download. Using existing file {destination_file_name}")
         return
     storage_client = storage.Client()

--- a/packages/toolbox-langchain/integration.cloudbuild.yaml
+++ b/packages/toolbox-langchain/integration.cloudbuild.yaml
@@ -31,6 +31,16 @@ steps:
         uv pip install -r requirements.txt
         uv pip install -e '.[test]'
     entrypoint: /bin/bash
+  - id: Extract patched server binary
+    name: 'gcr.io/cloud-builders/docker'
+    dir: 'packages/toolbox-langchain'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker create --name temp_toolbox us-central1-docker.pkg.dev/database-toolbox/toolbox-dev/toolbox:fix-meta
+        docker cp temp_toolbox:/toolbox ./toolbox
+        docker rm temp_toolbox
   - id: Run integration tests
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-langchain'
@@ -39,6 +49,7 @@ steps:
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID
       - TOOLBOX_MANIFEST_VERSION=${_TOOLBOX_MANIFEST_VERSION}
+      - TOOLBOX_SKIP_DOWNLOAD=true
     args:
       - '-c'
       - |

--- a/packages/toolbox-langchain/tests/conftest.py
+++ b/packages/toolbox-langchain/tests/conftest.py
@@ -60,6 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+        print(f"Skipping download. Using existing file {destination_file_name}")
+        return
     storage_client = storage.Client()
 
     bucket = storage_client.bucket(bucket_name)

--- a/packages/toolbox-langchain/tests/conftest.py
+++ b/packages/toolbox-langchain/tests/conftest.py
@@ -60,7 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
-    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(
+        destination_file_name
+    ):
         print(f"Skipping download. Using existing file {destination_file_name}")
         return
     storage_client = storage.Client()

--- a/packages/toolbox-llamaindex/integration.cloudbuild.yaml
+++ b/packages/toolbox-llamaindex/integration.cloudbuild.yaml
@@ -31,6 +31,16 @@ steps:
         uv pip install -r requirements.txt
         uv pip install -e '.[test]'
     entrypoint: /bin/bash
+  - id: Extract patched server binary
+    name: 'gcr.io/cloud-builders/docker'
+    dir: 'packages/toolbox-llamaindex'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker create --name temp_toolbox us-central1-docker.pkg.dev/database-toolbox/toolbox-dev/toolbox:fix-meta
+        docker cp temp_toolbox:/toolbox ./toolbox
+        docker rm temp_toolbox
   - id: Run integration tests
     name: 'python:${_VERSION}'
     dir: 'packages/toolbox-llamaindex'
@@ -39,6 +49,7 @@ steps:
       - TOOLBOX_VERSION=$_TOOLBOX_VERSION
       - GOOGLE_CLOUD_PROJECT=$PROJECT_ID
       - TOOLBOX_MANIFEST_VERSION=${_TOOLBOX_MANIFEST_VERSION}
+      - TOOLBOX_SKIP_DOWNLOAD=true
     args:
       - '-c'
       - |

--- a/packages/toolbox-llamaindex/tests/conftest.py
+++ b/packages/toolbox-llamaindex/tests/conftest.py
@@ -60,6 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+        print(f"Skipping download. Using existing file {destination_file_name}")
+        return
     storage_client = storage.Client()
 
     bucket = storage_client.bucket(bucket_name)

--- a/packages/toolbox-llamaindex/tests/conftest.py
+++ b/packages/toolbox-llamaindex/tests/conftest.py
@@ -60,7 +60,9 @@ def download_blob(
     bucket_name: str, source_blob_name: str, destination_file_name: str
 ) -> None:
     """Downloads a blob from a GCS bucket."""
-    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(destination_file_name):
+    if os.environ.get("TOOLBOX_SKIP_DOWNLOAD") == "true" and os.path.exists(
+        destination_file_name
+    ):
         print(f"Skipping download. Using existing file {destination_file_name}")
         return
     storage_client = storage.Client()


### PR DESCRIPTION
> [!NOTE]
> This is a temporary PR to test changes from https://github.com/googleapis/mcp-toolbox/pull/3300.

This PR skips GCS download, and instead extracts the patched binary in GCB. Before the integration tests run, GCB will execute a step that spins up the `toolbox:fix-meta` image in a temporary container, copy the `/toolbox` binary into the workspace, and trigger `pytest` with `TOOLBOX_SKIP_DOWNLOAD=true`.

