### PR TITLE
fix(toolbox-core): cache Google ID tokens per audience to prevent cross-audience token reuse

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/auth_methods.py
+++ b/packages/toolbox-core/src/toolbox_core/auth_methods.py
@@ -47,6 +47,12 @@ DEFAULT_CLOCK_SKEW = 0
 # via its `aud` claim, so a token minted for audience A must never be returned
 # for a request targeting audience B (doing so would leak a credential for A to
 # B and break OIDC audience isolation).
+#
+# A key of None is the local/user-credentials (ADC) path: the token is taken
+# from the credentials' own `id_token` rather than fetched for a specific
+# audience. That token's audience is fixed when the credentials are issued (not
+# by a per-call value), so all audience-less calls safely share the single None
+# entry and never mix with audience-specific entries.
 _CacheKey = Optional[str]
 _token_cache: Dict[_CacheKey, Dict[str, Any]] = {}
 

--- a/packages/toolbox-core/src/toolbox_core/auth_methods.py
+++ b/packages/toolbox-core/src/toolbox_core/auth_methods.py
@@ -31,7 +31,7 @@ as toolbox:
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Coroutine, Dict, Optional
+from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
 
 import google.auth
 from google.auth.exceptions import GoogleAuthError
@@ -43,26 +43,33 @@ BEARER_TOKEN_PREFIX = "Bearer "
 CACHE_REFRESH_MARGIN = timedelta(seconds=60)
 DEFAULT_CLOCK_SKEW = 0
 
-_token_cache: Dict[str, Any] = {
-    "token": None,
-    "expires_at": datetime.min.replace(tzinfo=timezone.utc),
-}
+# The cache is keyed by (audience, clock_skew_in_seconds). Keying by audience is
+# required for correctness and security: an ID token is scoped to a single
+# audience via its `aud` claim, so a token minted for audience A must never be
+# returned for a request targeting audience B (doing so leaks a credential for A
+# to B and breaks OIDC audience isolation). `clock_skew_in_seconds` is part of
+# the key because it changes how expiry is validated.
+_CacheKey = Tuple[Optional[str], int]
+_token_cache: Dict[_CacheKey, Dict[str, Any]] = {}
 
 
-def _is_token_valid() -> bool:
-    """Checks if the cached token exists and is not nearing expiry."""
-    if not _token_cache["token"]:
+def _is_token_valid(cache_key: _CacheKey) -> bool:
+    """Checks if a cached token for the given key exists and is not nearing expiry."""
+    entry = _token_cache.get(cache_key)
+    if not entry or not entry.get("token"):
         return False
-    return datetime.now(timezone.utc) < (
-        _token_cache["expires_at"] - CACHE_REFRESH_MARGIN
-    )
+    return datetime.now(timezone.utc) < (entry["expires_at"] - CACHE_REFRESH_MARGIN)
 
 
-def _update_cache(new_token: str, clock_skew_in_seconds: int) -> None:
+def _update_cache(
+    cache_key: _CacheKey, new_token: str, clock_skew_in_seconds: int
+) -> None:
     """
-    Validates a new token, extracts its expiry, and updates the cache.
+    Validates a new token, extracts its expiry, and updates the cache entry for
+    the given key.
 
     Args:
+        cache_key: The (audience, clock_skew_in_seconds) the token was fetched for.
         new_token: The new JWT ID token string.
 
     Raises:
@@ -80,15 +87,14 @@ def _update_cache(new_token: str, clock_skew_in_seconds: int) -> None:
         if not expiry_timestamp:
             raise ValueError("Token does not contain an 'exp' claim.")
 
-        _token_cache["token"] = new_token
-        _token_cache["expires_at"] = datetime.fromtimestamp(
-            expiry_timestamp, tz=timezone.utc
-        )
+        _token_cache[cache_key] = {
+            "token": new_token,
+            "expires_at": datetime.fromtimestamp(expiry_timestamp, tz=timezone.utc),
+        }
 
     except (ValueError, GoogleAuthError) as e:
-        # Clear cache on failure to prevent using a stale or invalid token
-        _token_cache["token"] = None
-        _token_cache["expires_at"] = datetime.min.replace(tzinfo=timezone.utc)
+        # Drop this key's entry on failure to prevent using a stale/invalid token
+        _token_cache.pop(cache_key, None)
         raise ValueError(f"Failed to validate and cache the new token: {e}") from e
 
 
@@ -101,8 +107,10 @@ def get_google_token_from_aud(
             ", inclusive."
         )
 
-    if _is_token_valid():
-        return BEARER_TOKEN_PREFIX + _token_cache["token"]
+    cache_key: _CacheKey = (audience, clock_skew_in_seconds)
+
+    if _is_token_valid(cache_key):
+        return BEARER_TOKEN_PREFIX + _token_cache[cache_key]["token"]
 
     # Get local user credentials
     credentials, _ = google.auth.default()
@@ -113,7 +121,7 @@ def get_google_token_from_aud(
     if hasattr(credentials, "id_token"):
         new_id_token = getattr(credentials, "id_token", None)
         if new_id_token:
-            _update_cache(new_id_token, clock_skew_in_seconds)
+            _update_cache(cache_key, new_id_token, clock_skew_in_seconds)
             return BEARER_TOKEN_PREFIX + new_id_token
 
     if audience is None:
@@ -126,8 +134,8 @@ def get_google_token_from_aud(
     try:
         request = Request()
         new_token = id_token.fetch_id_token(request, audience)
-        _update_cache(new_token, clock_skew_in_seconds)
-        return BEARER_TOKEN_PREFIX + _token_cache["token"]
+        _update_cache(cache_key, new_token, clock_skew_in_seconds)
+        return BEARER_TOKEN_PREFIX + _token_cache[cache_key]["token"]
 
     except GoogleAuthError as e:
         raise GoogleAuthError(
@@ -142,7 +150,7 @@ def get_google_id_token(
     Returns a SYNC function that, when called, fetches a Google ID token.
     This function uses Application Default Credentials for local systems
     and standard google auth libraries for Google Cloud environments.
-    It caches the token in memory.
+    It caches the token in memory, keyed by audience.
 
     Args:
         audience: The audience for the ID token (e.g., a service URL or client
@@ -171,7 +179,7 @@ def aget_google_id_token(
     Returns an ASYNC function that, when called, fetches a Google ID token.
     This function uses Application Default Credentials for local systems
     and standard google auth libraries for Google Cloud environments.
-    It caches the token in memory.
+    It caches the token in memory, keyed by audience.
 
     Args:
         audience: The audience for the ID token (e.g., a service URL or client

--- a/packages/toolbox-core/src/toolbox_core/auth_methods.py
+++ b/packages/toolbox-core/src/toolbox_core/auth_methods.py
@@ -31,7 +31,7 @@ as toolbox:
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
+from typing import Any, Callable, Coroutine, Dict, Optional
 
 import google.auth
 from google.auth.exceptions import GoogleAuthError
@@ -43,13 +43,11 @@ BEARER_TOKEN_PREFIX = "Bearer "
 CACHE_REFRESH_MARGIN = timedelta(seconds=60)
 DEFAULT_CLOCK_SKEW = 0
 
-# The cache is keyed by (audience, clock_skew_in_seconds). Keying by audience is
-# required for correctness and security: an ID token is scoped to a single
-# audience via its `aud` claim, so a token minted for audience A must never be
-# returned for a request targeting audience B (doing so leaks a credential for A
-# to B and breaks OIDC audience isolation). `clock_skew_in_seconds` is part of
-# the key because it changes how expiry is validated.
-_CacheKey = Tuple[Optional[str], int]
+# The cache is keyed by `audience`: an ID token is scoped to a single audience
+# via its `aud` claim, so a token minted for audience A must never be returned
+# for a request targeting audience B (doing so would leak a credential for A to
+# B and break OIDC audience isolation).
+_CacheKey = Optional[str]
 _token_cache: Dict[_CacheKey, Dict[str, Any]] = {}
 
 
@@ -69,8 +67,10 @@ def _update_cache(
     the given key.
 
     Args:
-        cache_key: The (audience, clock_skew_in_seconds) the token was fetched for.
+        cache_key: The audience the token was fetched for (used as the cache key).
         new_token: The new JWT ID token string.
+        clock_skew_in_seconds: Leeway, in seconds, forwarded to token verification
+            when validating the token's time-based claims.
 
     Raises:
         ValueError: If the token is invalid or its expiry cannot be determined.
@@ -107,7 +107,7 @@ def get_google_token_from_aud(
             ", inclusive."
         )
 
-    cache_key: _CacheKey = (audience, clock_skew_in_seconds)
+    cache_key: _CacheKey = audience
 
     if _is_token_valid(cache_key):
         return BEARER_TOKEN_PREFIX + _token_cache[cache_key]["token"]

--- a/packages/toolbox-core/tests/test_auth_methods.py
+++ b/packages/toolbox-core/tests/test_auth_methods.py
@@ -24,9 +24,8 @@ from toolbox_core import auth_methods
 MOCK_ID_TOKEN = "test_id_token_123"
 MOCK_PROJECT_ID = "test-project"
 MOCK_AUDIENCE = "https://test-audience.com"
-# The cache is keyed by (audience, clock_skew_in_seconds); the helpers default
-# clock_skew to 0, so this is the key the tests below operate on.
-MOCK_CACHE_KEY = (MOCK_AUDIENCE, 0)
+# The cache is keyed by `audience`.
+MOCK_CACHE_KEY = MOCK_AUDIENCE
 # A realistic expiry timestamp (e.g., 1 hour from now)
 MOCK_EXPIRY_TIMESTAMP = int(time.time()) + 3600
 MOCK_EXPIRY_DATETIME = auth_methods.datetime.fromtimestamp(

--- a/packages/toolbox-core/tests/test_auth_methods.py
+++ b/packages/toolbox-core/tests/test_auth_methods.py
@@ -24,6 +24,9 @@ from toolbox_core import auth_methods
 MOCK_ID_TOKEN = "test_id_token_123"
 MOCK_PROJECT_ID = "test-project"
 MOCK_AUDIENCE = "https://test-audience.com"
+# The cache is keyed by (audience, clock_skew_in_seconds); the helpers default
+# clock_skew to 0, so this is the key the tests below operate on.
+MOCK_CACHE_KEY = (MOCK_AUDIENCE, 0)
 # A realistic expiry timestamp (e.g., 1 hour from now)
 MOCK_EXPIRY_TIMESTAMP = int(time.time()) + 3600
 MOCK_EXPIRY_DATETIME = auth_methods.datetime.fromtimestamp(
@@ -35,13 +38,10 @@ MOCK_EXPIRY_DATETIME = auth_methods.datetime.fromtimestamp(
 def reset_cache():
     """Fixture to reset the module's token cache before each test."""
     original_cache = auth_methods._token_cache.copy()
-    # Reset to the initial empty state as defined in the new module
-    auth_methods._token_cache["token"] = None
-    auth_methods._token_cache["expires_at"] = auth_methods.datetime.min.replace(
-        tzinfo=auth_methods.timezone.utc
-    )
+    auth_methods._token_cache.clear()
     yield
-    auth_methods._token_cache = original_cache
+    auth_methods._token_cache.clear()
+    auth_methods._token_cache.update(original_cache)
 
 
 @pytest.mark.asyncio
@@ -67,16 +67,20 @@ class TestAsyncAuthMethods:
         mock_default.assert_called_once()
         mock_fetch.assert_called_once_with(ANY, MOCK_AUDIENCE)
         assert token == f"{auth_methods.BEARER_TOKEN_PREFIX}{MOCK_ID_TOKEN}"
-        assert auth_methods._token_cache["token"] == MOCK_ID_TOKEN
-        assert auth_methods._token_cache["expires_at"] == MOCK_EXPIRY_DATETIME
+        assert auth_methods._token_cache[MOCK_CACHE_KEY]["token"] == MOCK_ID_TOKEN
+        assert (
+            auth_methods._token_cache[MOCK_CACHE_KEY]["expires_at"]
+            == MOCK_EXPIRY_DATETIME
+        )
 
     @patch("toolbox_core.auth_methods.google.auth.default")
     async def test_aget_google_id_token_success_uses_cache(self, mock_default):
         """Tests that subsequent calls use the cached token if valid."""
-        auth_methods._token_cache["token"] = MOCK_ID_TOKEN
-        auth_methods._token_cache["expires_at"] = auth_methods.datetime.now(
-            auth_methods.timezone.utc
-        ) + auth_methods.timedelta(hours=1)
+        auth_methods._token_cache[MOCK_CACHE_KEY] = {
+            "token": MOCK_ID_TOKEN,
+            "expires_at": auth_methods.datetime.now(auth_methods.timezone.utc)
+            + auth_methods.timedelta(hours=1),
+        }
 
         token_getter = auth_methods.aget_google_id_token(MOCK_AUDIENCE)
         token = await token_getter()
@@ -94,10 +98,11 @@ class TestAsyncAuthMethods:
         self, mock_default, mock_fetch, mock_verify
     ):
         """Tests that an expired cached token triggers a refresh."""
-        auth_methods._token_cache["token"] = "expired_token"
-        auth_methods._token_cache["expires_at"] = auth_methods.datetime.now(
-            auth_methods.timezone.utc
-        ) - auth_methods.timedelta(seconds=100)
+        auth_methods._token_cache[MOCK_CACHE_KEY] = {
+            "token": "expired_token",
+            "expires_at": auth_methods.datetime.now(auth_methods.timezone.utc)
+            - auth_methods.timedelta(seconds=100),
+        }
 
         mock_fetch.return_value = MOCK_ID_TOKEN
         mock_verify.return_value = {"exp": MOCK_EXPIRY_TIMESTAMP}
@@ -108,7 +113,38 @@ class TestAsyncAuthMethods:
         mock_default.assert_called_once()
         mock_fetch.assert_called_once()
         assert token == f"{auth_methods.BEARER_TOKEN_PREFIX}{MOCK_ID_TOKEN}"
-        assert auth_methods._token_cache["token"] == MOCK_ID_TOKEN
+        assert auth_methods._token_cache[MOCK_CACHE_KEY]["token"] == MOCK_ID_TOKEN
+
+    @patch("toolbox_core.auth_methods.id_token.verify_oauth2_token")
+    @patch("toolbox_core.auth_methods.id_token.fetch_id_token")
+    @patch(
+        "toolbox_core.auth_methods.google.auth.default",
+        return_value=(MagicMock(id_token=None), MOCK_PROJECT_ID),
+    )
+    async def test_token_cache_is_keyed_by_audience(
+        self, mock_default, mock_fetch, mock_verify
+    ):
+        """Regression test: a token fetched for one audience must NOT be returned
+        for a getter configured with a different audience.
+
+        On the unpatched code (single global cache slot) the second getter would
+        return the first audience's token and fetch_id_token would be called only
+        once. This test fails there and passes once the cache is keyed by audience.
+        """
+        aud_a = "https://service-a.example"
+        aud_b = "https://service-b.example"
+        # Each minted token embeds the audience it was requested for.
+        mock_fetch.side_effect = lambda request, audience: f"token-for::{audience}"
+        mock_verify.return_value = {"exp": MOCK_EXPIRY_TIMESTAMP}
+
+        token_a = await auth_methods.aget_google_id_token(aud_a)()
+        token_b = await auth_methods.aget_google_id_token(aud_b)()
+
+        assert token_a == f"{auth_methods.BEARER_TOKEN_PREFIX}token-for::{aud_a}"
+        assert token_b == f"{auth_methods.BEARER_TOKEN_PREFIX}token-for::{aud_b}"
+        assert token_a != token_b
+        # Both audiences must have independently minted their own token.
+        assert mock_fetch.call_count == 2
 
     @patch("toolbox_core.auth_methods.id_token.fetch_id_token")
     @patch(
@@ -156,16 +192,20 @@ class TestSyncAuthMethods:
         mock_creds.refresh.assert_called_once_with(mock_request_instance)
         mock_verify.assert_called_once_with(MOCK_ID_TOKEN, ANY, clock_skew_in_seconds=0)
         assert token == f"{auth_methods.BEARER_TOKEN_PREFIX}{MOCK_ID_TOKEN}"
-        assert auth_methods._token_cache["token"] == MOCK_ID_TOKEN
-        assert auth_methods._token_cache["expires_at"] == MOCK_EXPIRY_DATETIME
+        assert auth_methods._token_cache[MOCK_CACHE_KEY]["token"] == MOCK_ID_TOKEN
+        assert (
+            auth_methods._token_cache[MOCK_CACHE_KEY]["expires_at"]
+            == MOCK_EXPIRY_DATETIME
+        )
 
     @patch("toolbox_core.auth_methods.google.auth.default")
     def test_get_google_id_token_success_uses_cache(self, mock_default):
         """Tests that subsequent calls use the cached token if valid."""
-        auth_methods._token_cache["token"] = MOCK_ID_TOKEN
-        auth_methods._token_cache["expires_at"] = auth_methods.datetime.now(
-            auth_methods.timezone.utc
-        ) + auth_methods.timedelta(hours=1)
+        auth_methods._token_cache[MOCK_CACHE_KEY] = {
+            "token": MOCK_ID_TOKEN,
+            "expires_at": auth_methods.datetime.now(auth_methods.timezone.utc)
+            + auth_methods.timedelta(hours=1),
+        }
 
         token_getter = auth_methods.get_google_id_token(MOCK_AUDIENCE)
         token = token_getter()
@@ -188,7 +228,7 @@ class TestSyncAuthMethods:
         with pytest.raises(GoogleAuthError, match="Fetch failed"):
             auth_methods.get_google_id_token(MOCK_AUDIENCE)()
 
-        assert auth_methods._token_cache["token"] is None
+        assert MOCK_CACHE_KEY not in auth_methods._token_cache
         mock_default.assert_called_once()
         mock_fetch.assert_called_once()
         mock_verify.assert_not_called()
@@ -211,7 +251,7 @@ class TestSyncAuthMethods:
         ):
             auth_methods.get_google_id_token(MOCK_AUDIENCE)()
 
-        assert auth_methods._token_cache["token"] is None
+        assert MOCK_CACHE_KEY not in auth_methods._token_cache
 
     @patch("toolbox_core.auth_methods.id_token.fetch_id_token")
     @patch(


### PR DESCRIPTION
## Summary
`toolbox_core.auth_methods` caches the fetched Google ID token in a single
module-level dict (`_token_cache`) that is not keyed by `audience`. When the
helper is used to authenticate to more than one Toolbox endpoint (different
audiences) in the same process, the token minted for the first audience is
returned for every subsequent getter — regardless of its configured audience —
until the entry nears expiry. This sends an ID token scoped to service A to
service B, breaking OIDC audience isolation (a credential-disclosure /
confused-deputy condition).

This was reported to the Google Security Team via the OSS VRP, which asked me to
fix it via a public PR.

## Fix
Key the in-memory cache by `audience` so each audience gets its own entry; tokens are never shared across audiences. (`clock_skew_in_seconds` only affects verification tolerance at fetch time, not what's cached, so it's intentionally not part of the key.) No public API changes.

## Tests
- Updated the existing `test_auth_methods.py` for the keyed-cache structure.
- Added `test_token_cache_is_keyed_by_audience`: two getters with different
  audiences must return different tokens and each must mint its own
  (fails on the old single-slot cache, passes with this change).

Local checks: `pytest`, `black --check`, `isort --check`, `mypy` all pass.