### PR TITLE
fix(toolbox-langchain): avoid duplicated parameter descriptions

### DIFF
--- a/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
@@ -21,7 +21,7 @@ from toolbox_core.utils import params_to_pydantic_model
 
 
 def _get_tool_description(core_tool: ToolboxCoreTool) -> str:
-    description = core_tool._description
+    description = getattr(core_tool, "_description", None)
     if isinstance(description, str):
         return description
     return core_tool.__doc__ or ""

--- a/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
@@ -20,6 +20,13 @@ from toolbox_core.tool import ToolboxTool as ToolboxCoreTool
 from toolbox_core.utils import params_to_pydantic_model
 
 
+def _get_tool_description(core_tool: ToolboxCoreTool) -> str:
+    description = core_tool._description
+    if isinstance(description, str):
+        return description
+    return core_tool.__doc__ or ""
+
+
 # This class is an internal implementation detail and is not exposed to the
 # end-user. It should not be used directly by external code. Changes to this
 # class will not be considered breaking changes to the public API.
@@ -44,7 +51,7 @@ class AsyncToolboxTool(BaseTool):
         # BaseTool class before assigning values to member variables.
         super().__init__(
             name=core_tool.__name__,
-            description=core_tool.__doc__,
+            description=_get_tool_description(core_tool),
             args_schema=params_to_pydantic_model(core_tool._name, core_tool._params),
         )
         self.__core_tool = core_tool

--- a/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
@@ -21,6 +21,13 @@ from toolbox_core.tool import ToolboxTool as ToolboxCoreTool
 from toolbox_core.utils import params_to_pydantic_model
 
 
+def _get_tool_description(core_tool: ToolboxCoreTool) -> str:
+    description = core_tool._description
+    if isinstance(description, str):
+        return description
+    return core_tool.__doc__ or ""
+
+
 # This class is an internal implementation detail and is not exposed to the
 # end-user. It should not be used directly by external code. Changes to this
 # class will not be considered breaking changes to the public API.
@@ -45,7 +52,7 @@ class AsyncToolboxTool(BaseTool):
         # BaseTool class before assigning values to member variables.
         super().__init__(
             name=core_tool.__name__,
-            description=core_tool.__doc__,
+            description=_get_tool_description(core_tool),
             args_schema=params_to_pydantic_model(core_tool._name, core_tool._params),
         )
         self.__core_tool = core_tool

--- a/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
@@ -22,7 +22,7 @@ from toolbox_core.utils import params_to_pydantic_model
 
 
 def _get_tool_description(core_tool: ToolboxCoreTool) -> str:
-    description = core_tool._description
+    description = getattr(core_tool, "_description", None)
     if isinstance(description, str):
         return description
     return core_tool.__doc__ or ""

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -21,6 +21,13 @@ from toolbox_core.sync_tool import ToolboxSyncTool as ToolboxCoreSyncTool
 from toolbox_core.utils import params_to_pydantic_model
 
 
+def _get_tool_description(core_tool: ToolboxCoreSyncTool) -> str:
+    description = core_tool._description
+    if isinstance(description, str):
+        return description
+    return core_tool.__doc__ or ""
+
+
 class ToolboxTool(BaseTool):
     """
     A subclass of LangChain's BaseTool that supports features specific to
@@ -42,7 +49,7 @@ class ToolboxTool(BaseTool):
         # BaseTool class before assigning values to member variables.
         super().__init__(
             name=core_tool.__name__,
-            description=core_tool.__doc__,
+            description=_get_tool_description(core_tool),
             args_schema=params_to_pydantic_model(core_tool._name, core_tool._params),
         )
         self.__core_tool = core_tool

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -22,7 +22,7 @@ from toolbox_core.utils import params_to_pydantic_model
 
 
 def _get_tool_description(core_tool: ToolboxCoreSyncTool) -> str:
-    description = core_tool._description
+    description = getattr(core_tool, "_description", None)
     if isinstance(description, str):
         return description
     return core_tool.__doc__ or ""

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -22,6 +22,13 @@ from toolbox_core.sync_tool import ToolboxSyncTool as ToolboxCoreSyncTool
 from toolbox_core.utils import params_to_pydantic_model
 
 
+def _get_tool_description(core_tool: ToolboxCoreSyncTool) -> str:
+    description = core_tool._description
+    if isinstance(description, str):
+        return description
+    return core_tool.__doc__ or ""
+
+
 class ToolboxTool(BaseTool):
     """
     A subclass of LangChain's BaseTool that supports features specific to
@@ -43,7 +50,7 @@ class ToolboxTool(BaseTool):
         # BaseTool class before assigning values to member variables.
         super().__init__(
             name=core_tool.__name__,
-            description=core_tool.__doc__,
+            description=_get_tool_description(core_tool),
             args_schema=params_to_pydantic_model(core_tool._name, core_tool._params),
         )
         self.__core_tool = core_tool

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -23,7 +23,7 @@ from toolbox_core.utils import params_to_pydantic_model
 
 
 def _get_tool_description(core_tool: ToolboxCoreSyncTool) -> str:
-    description = core_tool._description
+    description = getattr(core_tool, "_description", None)
     if isinstance(description, str):
         return description
     return core_tool.__doc__ or ""

--- a/packages/toolbox-langchain/tests/test_async_tools.py
+++ b/packages/toolbox-langchain/tests/test_async_tools.py
@@ -152,6 +152,21 @@ class TestAsyncToolboxTool:
         assert tool.description == core_tool_instance._description
         assert "Args:" not in tool.description
 
+    async def test_toolbox_tool_description_falls_back_to_docstring(
+        self, tool_schema_dict
+    ):
+        core_tool_instance = self._create_core_tool_from_dict(
+            session=None,
+            name="test_tool",
+            schema_dict=tool_schema_dict,
+            url="https://test-url",
+        )
+        core_tool_instance._ToolboxTool__description = None
+
+        tool = AsyncToolboxTool(core_tool=core_tool_instance)
+
+        assert tool.description == core_tool_instance.__doc__
+
     @pytest.mark.parametrize(
         "params_to_bind",
         [

--- a/packages/toolbox-langchain/tests/test_async_tools.py
+++ b/packages/toolbox-langchain/tests/test_async_tools.py
@@ -149,7 +149,8 @@ class TestAsyncToolboxTool:
         )
         tool = AsyncToolboxTool(core_tool=core_tool_instance)
         assert tool.name == "test_tool"
-        assert tool.description == core_tool_instance.__doc__
+        assert tool.description == core_tool_instance._description
+        assert "Args:" not in tool.description
 
     @pytest.mark.parametrize(
         "params_to_bind",

--- a/packages/toolbox-langchain/tests/test_async_tools.py
+++ b/packages/toolbox-langchain/tests/test_async_tools.py
@@ -153,6 +153,21 @@ class TestAsyncToolboxTool:
         assert tool.description == core_tool_instance._description
         assert "Args:" not in tool.description
 
+    async def test_toolbox_tool_description_falls_back_to_docstring(
+        self, tool_schema_dict
+    ):
+        core_tool_instance = self._create_core_tool_from_dict(
+            session=None,
+            name="test_tool",
+            schema_dict=tool_schema_dict,
+            url="https://test-url",
+        )
+        core_tool_instance._ToolboxTool__description = None
+
+        tool = AsyncToolboxTool(core_tool=core_tool_instance)
+
+        assert tool.description == core_tool_instance.__doc__
+
     @pytest.mark.parametrize(
         "params_to_bind",
         [

--- a/packages/toolbox-langchain/tests/test_async_tools.py
+++ b/packages/toolbox-langchain/tests/test_async_tools.py
@@ -150,7 +150,8 @@ class TestAsyncToolboxTool:
         )
         tool = AsyncToolboxTool(core_tool=core_tool_instance)
         assert tool.name == "test_tool"
-        assert tool.description == core_tool_instance.__doc__
+        assert tool.description == core_tool_instance._description
+        assert "Args:" not in tool.description
 
     @pytest.mark.parametrize(
         "params_to_bind",

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -216,6 +216,13 @@ class TestToolboxTool:
         # Verify defaults actually persisted from the schema correctly
         assert tool.args_schema.model_fields["param2"].default == 42
 
+    def test_toolbox_tool_description_falls_back_to_docstring(self, mock_core_tool):
+        del mock_core_tool._description
+
+        tool = ToolboxTool(core_tool=mock_core_tool)
+
+        assert tool.description == mock_core_tool.__doc__
+
     @pytest.mark.parametrize(
         "params",
         [

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -109,7 +109,13 @@ class TestToolboxTool:
         sync_mock = Mock(spec=ToolboxCoreSyncTool)
 
         sync_mock.__name__ = "test_tool_name_for_langchain"
-        sync_mock.__doc__ = tool_schema_dict["description"]
+        sync_mock._description = tool_schema_dict["description"]
+        sync_mock.__doc__ = (
+            f"{tool_schema_dict['description']}\n\n"
+            "Args:\n"
+            "    param1 (str): Param 1\n"
+            "    param2 (int): Param 2"
+        )
         sync_mock._name = "TestToolPydanticModel"
         sync_mock._params = [
             CoreParameterSchema(**p) for p in tool_schema_dict["parameters"]
@@ -123,6 +129,7 @@ class TestToolboxTool:
 
         new_mock_instance_for_methods = Mock(spec=ToolboxCoreSyncTool)
         new_mock_instance_for_methods.__name__ = sync_mock.__name__
+        new_mock_instance_for_methods._description = sync_mock._description
         new_mock_instance_for_methods.__doc__ = sync_mock.__doc__
         new_mock_instance_for_methods._name = sync_mock._name
         new_mock_instance_for_methods._params = sync_mock._params
@@ -145,7 +152,13 @@ class TestToolboxTool:
     def mock_core_sync_auth_tool(self, auth_tool_schema_dict):
         sync_mock = Mock(spec=ToolboxCoreSyncTool)
         sync_mock.__name__ = "test_auth_tool_lc_name"
-        sync_mock.__doc__ = auth_tool_schema_dict["description"]
+        sync_mock._description = auth_tool_schema_dict["description"]
+        sync_mock.__doc__ = (
+            f"{auth_tool_schema_dict['description']}\n\n"
+            "Args:\n"
+            "    param1 (str): Param 1\n"
+            "    param2 (int): Param 2"
+        )
         sync_mock._name = "TestAuthToolPydanticModel"
         sync_mock._params = [
             CoreParameterSchema(**p) for p in auth_tool_schema_dict["parameters"]
@@ -159,6 +172,7 @@ class TestToolboxTool:
 
         new_mock_instance_for_methods = Mock(spec=ToolboxCoreSyncTool)
         new_mock_instance_for_methods.__name__ = sync_mock.__name__
+        new_mock_instance_for_methods._description = sync_mock._description
         new_mock_instance_for_methods.__doc__ = sync_mock.__doc__
         new_mock_instance_for_methods._name = sync_mock._name
         new_mock_instance_for_methods._params = sync_mock._params
@@ -188,7 +202,8 @@ class TestToolboxTool:
         tool = ToolboxTool(core_tool=mock_core_tool)
 
         assert tool.name == mock_core_tool.__name__
-        assert tool.description == mock_core_tool.__doc__
+        assert tool.description == mock_core_tool._description
+        assert "Args:" not in tool.description
         assert tool._ToolboxTool__core_tool == mock_core_tool
 
         expected_args_schema = params_to_pydantic_model(

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -110,7 +110,13 @@ class TestToolboxTool:
         sync_mock = Mock(spec=ToolboxCoreSyncTool)
 
         sync_mock.__name__ = "test_tool_name_for_langchain"
-        sync_mock.__doc__ = tool_schema_dict["description"]
+        sync_mock._description = tool_schema_dict["description"]
+        sync_mock.__doc__ = (
+            f"{tool_schema_dict['description']}\n\n"
+            "Args:\n"
+            "    param1 (str): Param 1\n"
+            "    param2 (int): Param 2"
+        )
         sync_mock._name = "TestToolPydanticModel"
         sync_mock._params = [
             CoreParameterSchema(**p) for p in tool_schema_dict["parameters"]
@@ -124,6 +130,7 @@ class TestToolboxTool:
 
         new_mock_instance_for_methods = Mock(spec=ToolboxCoreSyncTool)
         new_mock_instance_for_methods.__name__ = sync_mock.__name__
+        new_mock_instance_for_methods._description = sync_mock._description
         new_mock_instance_for_methods.__doc__ = sync_mock.__doc__
         new_mock_instance_for_methods._name = sync_mock._name
         new_mock_instance_for_methods._params = sync_mock._params
@@ -151,7 +158,13 @@ class TestToolboxTool:
     def mock_core_sync_auth_tool(self, auth_tool_schema_dict):
         sync_mock = Mock(spec=ToolboxCoreSyncTool)
         sync_mock.__name__ = "test_auth_tool_lc_name"
-        sync_mock.__doc__ = auth_tool_schema_dict["description"]
+        sync_mock._description = auth_tool_schema_dict["description"]
+        sync_mock.__doc__ = (
+            f"{auth_tool_schema_dict['description']}\n\n"
+            "Args:\n"
+            "    param1 (str): Param 1\n"
+            "    param2 (int): Param 2"
+        )
         sync_mock._name = "TestAuthToolPydanticModel"
         sync_mock._params = [
             CoreParameterSchema(**p) for p in auth_tool_schema_dict["parameters"]
@@ -165,6 +178,7 @@ class TestToolboxTool:
 
         new_mock_instance_for_methods = Mock(spec=ToolboxCoreSyncTool)
         new_mock_instance_for_methods.__name__ = sync_mock.__name__
+        new_mock_instance_for_methods._description = sync_mock._description
         new_mock_instance_for_methods.__doc__ = sync_mock.__doc__
         new_mock_instance_for_methods._name = sync_mock._name
         new_mock_instance_for_methods._params = sync_mock._params
@@ -196,7 +210,8 @@ class TestToolboxTool:
         tool = ToolboxTool(core_tool=mock_core_tool)
 
         assert tool.name == mock_core_tool.__name__
-        assert tool.description == mock_core_tool.__doc__
+        assert tool.description == mock_core_tool._description
+        assert "Args:" not in tool.description
         assert tool._ToolboxTool__core_tool == mock_core_tool
 
         expected_args_schema = params_to_pydantic_model(

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -224,6 +224,13 @@ class TestToolboxTool:
         # Verify defaults actually persisted from the schema correctly
         assert tool.args_schema.model_fields["param2"].default == 42
 
+    def test_toolbox_tool_description_falls_back_to_docstring(self, mock_core_tool):
+        del mock_core_tool._description
+
+        tool = ToolboxTool(core_tool=mock_core_tool)
+
+        assert tool.description == mock_core_tool.__doc__
+
     @pytest.mark.parametrize(
         "params",
         [


### PR DESCRIPTION
Fixes googleapis/mcp-toolbox#1327.

LangChain tools currently use the core tool `__doc__` as the `BaseTool` description. The core docstring intentionally appends an `Args:` section for Python introspection, but LangChain already receives parameter descriptions through `args_schema`, so the LLM-facing tool description duplicates every parameter description.

This changes the LangChain wrappers to use the core tool's raw `_description` when available, while preserving a fallback to `__doc__` for compatibility with older or mocked tool objects. Regression coverage checks that the LangChain tool description no longer includes `Args:` while parameter descriptions remain available through `args_schema`.

Validation:
- `pytest tests/test_client.py tests/test_async_client.py tests/test_tools.py tests/test_async_tools.py`
- `black --check src tests`
- `isort --check src tests`
- `MYPYPATH='./src:../toolbox-core/src' mypy --install-types --non-interactive --cache-dir=.mypy_cache/ -p toolbox_langchain`

Note: the full `pytest tests` suite includes E2E coverage that expects a Toolbox service/version environment, so I used the non-E2E LangChain package test set above for this wrapper change.
