### PR TITLE
feat: add support for stateless MCP 2026 draft and protocol negotiation fallback

### DIFF
--- a/packages/toolbox-adk/integration.cloudbuild.yaml
+++ b/packages/toolbox-adk/integration.cloudbuild.yaml
@@ -50,5 +50,5 @@ options:
 substitutions:
   _VERSION: '3.13'
   # Default values (can be overridden by triggers)
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: '1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-adk/pyproject.toml
+++ b/packages/toolbox-adk/pyproject.toml
@@ -40,7 +40,8 @@ test = [
     "pytest==9.0.3",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
-    "pytest-mock==3.15.1"
+    "pytest-mock==3.15.1",
+    "numpy<2", # Pinned to <2 to prevent mypy syntax errors on python 3.10 with numpy 2.x stubs,
 ]
 
 # Tells setuptools that packages are under the 'src' directory

--- a/packages/toolbox-adk/src/toolbox_adk/tool.py
+++ b/packages/toolbox-adk/src/toolbox_adk/tool.py
@@ -17,11 +17,7 @@ import logging
 from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
 
 import toolbox_core
-from fastapi.openapi.models import (
-    OAuth2,
-    OAuthFlowAuthorizationCode,
-    OAuthFlows,
-)
+from fastapi.openapi.models import OAuth2, OAuthFlowAuthorizationCode, OAuthFlows
 from google.adk.auth.auth_credential import (
     AuthCredential,
     AuthCredentialTypes,

--- a/packages/toolbox-adk/tests/constants.py
+++ b/packages/toolbox-adk/tests/constants.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"

--- a/packages/toolbox-adk/tests/integration/conftest.py
+++ b/packages/toolbox-adk/tests/integration/conftest.py
@@ -25,9 +25,12 @@ import time
 from typing import Generator
 
 import google
-import pytest_asyncio
+import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
 
 
 #### Define Utility Functions
@@ -92,17 +95,17 @@ def get_auth_token(client_id: str) -> str:
 
 
 #### Define Fixtures
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def project_id() -> str:
     return get_env_var("GOOGLE_CLOUD_PROJECT")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_version() -> str:
     return get_env_var("TOOLBOX_VERSION")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def tools_file_path(project_id: str) -> Generator[str]:
     """Provides a temporary file path containing the tools manifest."""
     if os.environ.get("TEST_MOCK_GCP"):
@@ -122,7 +125,7 @@ def tools_file_path(project_id: str) -> Generator[str]:
     os.remove(tools_file_path)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token1(project_id: str) -> str:
     if os.environ.get("TEST_MOCK_GCP"):
         return "mock-token-1"
@@ -132,7 +135,7 @@ def auth_token1(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token2(project_id: str) -> str:
     if os.environ.get("TEST_MOCK_GCP"):
         return "mock-token-2"
@@ -142,7 +145,7 @@ def auth_token2(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None]:
     """Starts the toolbox server as a subprocess."""
     if os.environ.get("TEST_MOCK_GCP"):
@@ -159,20 +162,30 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
         # Make toolbox executable
         os.chmod("toolbox", 0o700)
         # Run toolbox binary
-        toolbox_server = subprocess.Popen(
-            ["./toolbox", "--tools-file", tools_file_path]
+        toolbox_server_1 = subprocess.Popen(
+            ["./toolbox", "--port", "5000", "--tools-file", tools_file_path]
+        )
+        toolbox_server_2 = subprocess.Popen(
+            [
+                "./toolbox",
+                "--port",
+                "5001",
+                "--tools-file",
+                tools_file_path,
+                "--enable-draft-specs",
+            ]
         )
 
         # Wait for server to start
         # Retry logic with a timeout
         for _ in range(5):  # retries
             time.sleep(2)
-            print("Checking if toolbox is successfully started...")
-            if toolbox_server.poll() is None:
-                print("Toolbox server started successfully.")
+            print("Checking if both toolbox servers are successfully started...")
+            if toolbox_server_1.poll() is None and toolbox_server_2.poll() is None:
+                print("Toolbox servers started successfully.")
                 break
         else:
-            raise RuntimeError("Toolbox server failed to start after 5 retries.")
+            raise RuntimeError("Toolbox servers failed to start after 5 retries.")
     except subprocess.CalledProcessError as e:
         print(e.stderr.decode("utf-8"))
         print(e.stdout.decode("utf-8"))
@@ -180,5 +193,31 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     yield
 
     # Clean up toolbox server
-    toolbox_server.terminate()
-    toolbox_server.wait(timeout=5)
+    toolbox_server_1.terminate()
+    toolbox_server_2.terminate()
+    toolbox_server_1.wait(timeout=5)
+    toolbox_server_2.wait(timeout=5)
+
+
+@pytest.fixture(
+    params=[TOOLBOX_SERVER_URL_STABLE, TOOLBOX_SERVER_URL_DRAFT], scope="session"
+)
+def toolbox_server_url(request) -> str:
+    return request.param
+
+
+@pytest.fixture()
+def patch_toolbox_client_url(toolbox_server_url):
+    from toolbox_adk.toolset import ToolboxToolset
+
+    original_init = ToolboxToolset.__init__
+
+    def new_init(self, server_url=TOOLBOX_SERVER_URL_STABLE, *args, **kwargs):
+        if server_url == TOOLBOX_SERVER_URL_STABLE:
+            server_url = toolbox_server_url
+        original_init(self, server_url, *args, **kwargs)
+
+    from unittest.mock import patch
+
+    with patch.object(ToolboxToolset, "__init__", new_init, create=True):
+        yield

--- a/packages/toolbox-adk/tests/integration/conftest.py
+++ b/packages/toolbox-adk/tests/integration/conftest.py
@@ -29,8 +29,7 @@ import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
 
-TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
-TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
+from tests.constants import TOOLBOX_SERVER_URL_DRAFT, TOOLBOX_SERVER_URL_STABLE
 
 
 #### Define Utility Functions

--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -31,9 +31,8 @@ from google.genai import types
 from pydantic import ValidationError
 from toolbox_core.protocol import Protocol
 
+from tests.constants import TOOLBOX_SERVER_URL_STABLE
 from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset
-
-TOOLBOX_SERVER_URL = "http://localhost:5000"
 
 pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
@@ -53,8 +52,11 @@ class TestToolboxAdkIntegration:
     async def test_load_toolset_and_run(self):
         # Auth: TOOLBOX_IDENTITY for simplicity in this local test as we don't have ADK identity setup.
 
+        # Note: The STABLE URL passed here is automatically patched by the
+        # 'patch_toolbox_client_url' fixture to run against both
+        # the STABLE (5000) and DRAFT (5001) servers.
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -88,7 +90,7 @@ class TestToolboxAdkIntegration:
     async def test_load_toolset_with_default_protocol(self):
         """Test initializing toolset with default protocol (MCP)."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -112,7 +114,7 @@ class TestToolboxAdkIntegration:
     async def test_load_toolset_with_explicit_protocol(self):
         """Test initializing toolset with specific protocol (MCP_v20251125)."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.toolbox_identity(),
             protocol=Protocol.MCP_v20251125,
@@ -136,7 +138,7 @@ class TestToolboxAdkIntegration:
 
     async def test_partial_loading_by_names(self):
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -156,7 +158,7 @@ class TestToolboxAdkIntegration:
     async def test_bound_params_e2e(self):
         # Test binding param at toolset level
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             bound_params={"num_rows": "2"},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -172,7 +174,7 @@ class TestToolboxAdkIntegration:
 
     async def test_3lo_flow_simulation(self):
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             # Load a specific tool that we know the arguments for
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.user_identity(
@@ -269,7 +271,7 @@ class TestToolboxAdkIntegration:
     async def test_manual_token_integration(self):
         """Test the MANUAL_TOKEN strategy."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.manual_token(token="fake-manual-token"),
         )
@@ -288,7 +290,7 @@ class TestToolboxAdkIntegration:
         mock_creds.token = "fake-creds-token"
 
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.manual_credentials(credentials=mock_creds),
         )
@@ -301,7 +303,7 @@ class TestToolboxAdkIntegration:
     async def test_api_key_integration(self):
         """Test the API_KEY strategy."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.api_key(key="my-key", header_name="x-foo"),
         )
@@ -337,7 +339,7 @@ class TestToolboxAdkIntegration:
 
         # 3. Use in Toolset
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             credentials=strategy,
         )
@@ -361,7 +363,7 @@ class TestToolboxAdkIntegration:
         creds_token = "Bearer strategy-token"
 
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name="my-toolset",
             additional_headers={"Authorization": manual_override},
             credentials=CredentialStrategy.manual_token(token="strategy-token"),
@@ -395,7 +397,7 @@ class TestBasicE2E:
     ):
         """Load a specific toolset"""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             toolset_name=toolset_name,
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -410,7 +412,7 @@ class TestBasicE2E:
     async def test_load_toolset_default(self):
         """Load the default toolset, i.e. all tools."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             credentials=CredentialStrategy.toolbox_identity(),
         )
         try:
@@ -433,7 +435,7 @@ class TestBasicE2E:
     async def test_run_tool(self):
         """Invoke a tool."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -455,7 +457,7 @@ class TestBasicE2E:
     async def test_run_tool_missing_params(self):
         """Invoke a tool with missing params."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -474,7 +476,7 @@ class TestBasicE2E:
     async def test_run_tool_wrong_param_type(self):
         """Invoke a tool with wrong param type."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -498,7 +500,7 @@ class TestBindParams:
     async def test_bind_params(self):
         """Bind a param to an existing tool."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             bound_params={"num_rows": "3"},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -520,7 +522,7 @@ class TestBindParams:
     async def test_bind_params_callable(self):
         """Bind a callable param to an existing tool."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-n-rows"],
             bound_params={"num_rows": lambda: "3"},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -546,7 +548,7 @@ class TestAuth:
     async def test_run_tool_unauth_with_auth(self, auth_token2: str):
         """Tests running a tool that doesn't require auth, with auth provided."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-row-by-id"],
             auth_token_getters={"my-test-auth": lambda: auth_token2},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -563,7 +565,7 @@ class TestAuth:
     async def test_run_multiple_tools_unauth_with_auth(self, auth_token2: str):
         """Tests running multiple tools that don't require auth, verifying formatting of tool lists."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-row-by-id", "search-rows"],
             auth_token_getters={"my-test-auth": lambda: auth_token2},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -580,7 +582,7 @@ class TestAuth:
     async def test_run_multiple_tools_partial_auth_usage(self, auth_token2: str):
         """Tests that when some tokens are used and some aren't across diverse tools, only the truly unused tokens appear in the error."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=[
                 "get-row-by-id-auth",
                 "search-rows",
@@ -605,7 +607,7 @@ class TestAuth:
         """Tests running a tool requiring auth without providing auth."""
         # Note: We load it without auth getters. Invocation should fail.
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-row-by-id-auth"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -625,7 +627,7 @@ class TestAuth:
     async def test_run_tool_wrong_auth(self, auth_token2: str):
         """Tests running a tool with incorrect auth."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-row-by-id-auth"],
             auth_token_getters={"my-test-auth": lambda: auth_token2},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -635,18 +637,21 @@ class TestAuth:
             tool = tools[0]
             ctx = MagicMock()
 
-            with pytest.raises(
-                Exception,
-                match=r"401 \(Unauthorized\)",
-            ):
+            try:
                 await tool.run_async({"id": "2"}, ctx)
+                pytest.fail("Expected tool to fail with auth error")
+            except Exception as e:
+                err_str = str(e)
+                assert (
+                    "401" in err_str or "-32600" in err_str
+                ), f"Unexpected error message: {err_str}"
         finally:
             await toolset.close()
 
     async def test_run_tool_auth(self, auth_token1: str):
         """Tests running a tool with correct auth."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-row-by-id-auth"],
             auth_token_getters={"my-test-auth": lambda: auth_token1},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -668,7 +673,7 @@ class TestAuth:
             return auth_token1
 
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["get-row-by-id-auth"],
             auth_token_getters={"my-test-auth": get_token_asynchronously},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -694,7 +699,7 @@ class TestOptionalParams:
     async def test_run_tool_with_optional_params_omitted(self):
         """Invoke a tool providing only the required parameter."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["search-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -713,7 +718,7 @@ class TestOptionalParams:
     async def test_run_tool_with_all_valid_params(self):
         """Invoke a tool providing all parameters."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["search-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -733,7 +738,7 @@ class TestOptionalParams:
     async def test_run_tool_with_missing_required_param(self):
         """Invoke a tool without its required parameter."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["search-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -758,7 +763,7 @@ class TestMapParams:
     async def test_run_tool_with_map_params(self):
         """Invoke a tool with valid map parameters."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["process-data"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -789,7 +794,7 @@ class TestMapParams:
     async def test_run_tool_with_wrong_map_value_type(self):
         """Invoke a tool with a map parameter having the wrong value type."""
         toolset = ToolboxToolset(
-            server_url=TOOLBOX_SERVER_URL,
+            server_url=TOOLBOX_SERVER_URL_STABLE,
             tool_names=["process-data"],
             credentials=CredentialStrategy.toolbox_identity(),
         )

--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -35,6 +35,8 @@ from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset
 
 TOOLBOX_SERVER_URL = "http://localhost:5000"
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 # Ensure TOOLBOX_VERSION is set for the fixture
 if "TOOLBOX_VERSION" not in os.environ:
     os.environ["TOOLBOX_VERSION"] = "0.0.1"  # Use a valid version or mock

--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -33,6 +33,8 @@ from toolbox_core.protocol import Protocol
 
 from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset
 
+TOOLBOX_SERVER_URL = "http://localhost:5000"
+
 # Ensure TOOLBOX_VERSION is set for the fixture
 if "TOOLBOX_VERSION" not in os.environ:
     os.environ["TOOLBOX_VERSION"] = "0.0.1"  # Use a valid version or mock
@@ -50,7 +52,7 @@ class TestToolboxAdkIntegration:
         # Auth: TOOLBOX_IDENTITY for simplicity in this local test as we don't have ADK identity setup.
 
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -84,7 +86,7 @@ class TestToolboxAdkIntegration:
     async def test_load_toolset_with_default_protocol(self):
         """Test initializing toolset with default protocol (MCP)."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -108,7 +110,7 @@ class TestToolboxAdkIntegration:
     async def test_load_toolset_with_explicit_protocol(self):
         """Test initializing toolset with specific protocol (MCP_v20251125)."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.toolbox_identity(),
             protocol=Protocol.MCP_v20251125,
@@ -132,7 +134,7 @@ class TestToolboxAdkIntegration:
 
     async def test_partial_loading_by_names(self):
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -152,7 +154,7 @@ class TestToolboxAdkIntegration:
     async def test_bound_params_e2e(self):
         # Test binding param at toolset level
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             bound_params={"num_rows": "2"},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -168,7 +170,7 @@ class TestToolboxAdkIntegration:
 
     async def test_3lo_flow_simulation(self):
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             # Load a specific tool that we know the arguments for
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.user_identity(
@@ -265,7 +267,7 @@ class TestToolboxAdkIntegration:
     async def test_manual_token_integration(self):
         """Test the MANUAL_TOKEN strategy."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.manual_token(token="fake-manual-token"),
         )
@@ -284,7 +286,7 @@ class TestToolboxAdkIntegration:
         mock_creds.token = "fake-creds-token"
 
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.manual_credentials(credentials=mock_creds),
         )
@@ -297,7 +299,7 @@ class TestToolboxAdkIntegration:
     async def test_api_key_integration(self):
         """Test the API_KEY strategy."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=CredentialStrategy.api_key(key="my-key", header_name="x-foo"),
         )
@@ -333,7 +335,7 @@ class TestToolboxAdkIntegration:
 
         # 3. Use in Toolset
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             credentials=strategy,
         )
@@ -357,7 +359,7 @@ class TestToolboxAdkIntegration:
         creds_token = "Bearer strategy-token"
 
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name="my-toolset",
             additional_headers={"Authorization": manual_override},
             credentials=CredentialStrategy.manual_token(token="strategy-token"),
@@ -391,7 +393,7 @@ class TestBasicE2E:
     ):
         """Load a specific toolset"""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             toolset_name=toolset_name,
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -406,7 +408,7 @@ class TestBasicE2E:
     async def test_load_toolset_default(self):
         """Load the default toolset, i.e. all tools."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             credentials=CredentialStrategy.toolbox_identity(),
         )
         try:
@@ -429,7 +431,7 @@ class TestBasicE2E:
     async def test_run_tool(self):
         """Invoke a tool."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -451,7 +453,7 @@ class TestBasicE2E:
     async def test_run_tool_missing_params(self):
         """Invoke a tool with missing params."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -470,7 +472,7 @@ class TestBasicE2E:
     async def test_run_tool_wrong_param_type(self):
         """Invoke a tool with wrong param type."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -494,7 +496,7 @@ class TestBindParams:
     async def test_bind_params(self):
         """Bind a param to an existing tool."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             bound_params={"num_rows": "3"},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -516,7 +518,7 @@ class TestBindParams:
     async def test_bind_params_callable(self):
         """Bind a callable param to an existing tool."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-n-rows"],
             bound_params={"num_rows": lambda: "3"},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -542,7 +544,7 @@ class TestAuth:
     async def test_run_tool_unauth_with_auth(self, auth_token2: str):
         """Tests running a tool that doesn't require auth, with auth provided."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-row-by-id"],
             auth_token_getters={"my-test-auth": lambda: auth_token2},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -559,7 +561,7 @@ class TestAuth:
     async def test_run_multiple_tools_unauth_with_auth(self, auth_token2: str):
         """Tests running multiple tools that don't require auth, verifying formatting of tool lists."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-row-by-id", "search-rows"],
             auth_token_getters={"my-test-auth": lambda: auth_token2},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -576,7 +578,7 @@ class TestAuth:
     async def test_run_multiple_tools_partial_auth_usage(self, auth_token2: str):
         """Tests that when some tokens are used and some aren't across diverse tools, only the truly unused tokens appear in the error."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=[
                 "get-row-by-id-auth",
                 "search-rows",
@@ -601,7 +603,7 @@ class TestAuth:
         """Tests running a tool requiring auth without providing auth."""
         # Note: We load it without auth getters. Invocation should fail.
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-row-by-id-auth"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -621,7 +623,7 @@ class TestAuth:
     async def test_run_tool_wrong_auth(self, auth_token2: str):
         """Tests running a tool with incorrect auth."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-row-by-id-auth"],
             auth_token_getters={"my-test-auth": lambda: auth_token2},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -642,7 +644,7 @@ class TestAuth:
     async def test_run_tool_auth(self, auth_token1: str):
         """Tests running a tool with correct auth."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-row-by-id-auth"],
             auth_token_getters={"my-test-auth": lambda: auth_token1},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -664,7 +666,7 @@ class TestAuth:
             return auth_token1
 
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["get-row-by-id-auth"],
             auth_token_getters={"my-test-auth": get_token_asynchronously},
             credentials=CredentialStrategy.toolbox_identity(),
@@ -690,7 +692,7 @@ class TestOptionalParams:
     async def test_run_tool_with_optional_params_omitted(self):
         """Invoke a tool providing only the required parameter."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["search-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -709,7 +711,7 @@ class TestOptionalParams:
     async def test_run_tool_with_all_valid_params(self):
         """Invoke a tool providing all parameters."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["search-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -729,7 +731,7 @@ class TestOptionalParams:
     async def test_run_tool_with_missing_required_param(self):
         """Invoke a tool without its required parameter."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["search-rows"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -754,7 +756,7 @@ class TestMapParams:
     async def test_run_tool_with_map_params(self):
         """Invoke a tool with valid map parameters."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["process-data"],
             credentials=CredentialStrategy.toolbox_identity(),
         )
@@ -785,7 +787,7 @@ class TestMapParams:
     async def test_run_tool_with_wrong_map_value_type(self):
         """Invoke a tool with a map parameter having the wrong value type."""
         toolset = ToolboxToolset(
-            server_url="http://localhost:5000",
+            server_url=TOOLBOX_SERVER_URL,
             tool_names=["process-data"],
             credentials=CredentialStrategy.toolbox_identity(),
         )

--- a/packages/toolbox-adk/tests/unit/test_credentials.py
+++ b/packages/toolbox-adk/tests/unit/test_credentials.py
@@ -109,10 +109,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_api_key(self):
         from fastapi.openapi.models import APIKey, APIKeyIn
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.API_KEY, api_key="abc"
@@ -129,10 +126,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_api_key_default_location(self):
         from fastapi.openapi.models import APIKey
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.API_KEY, api_key="abc"
@@ -157,10 +151,7 @@ class TestCredentialStrategy:
     def test_from_adk_credentials_api_key_query_fail(self):
         import pytest
         from fastapi.openapi.models import APIKey, APIKeyIn
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         cred = AuthCredential(auth_type=AuthCredentialTypes.API_KEY, api_key="abc")
         scheme = APIKey(type="apiKey", name="key", **{"in": APIKeyIn.query})
@@ -172,10 +163,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_api_key_no_scheme_raises(self):
         import pytest
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.API_KEY, api_key="my-key"
@@ -187,10 +175,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_unsupported(self):
         import pytest
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.OAUTH2

--- a/packages/toolbox-core/README.md
+++ b/packages/toolbox-core/README.md
@@ -63,6 +63,7 @@ The core package provides a framework-agnostic way to interact with your Toolbox
 - [Authenticating Tools](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#authenticating-tools)
 - [Binding Parameter Values](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#parameter-binding)
 - [OpenTelemetry](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#opentelemetry)
+- [Protocol Negotiation](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#protocol-negotiation)
 
 
 # Contributing

--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -45,5 +45,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: '1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-core/pyproject.toml
+++ b/packages/toolbox-core/pyproject.toml
@@ -60,7 +60,8 @@ test = [
     "google-cloud-secret-manager==2.28.0",
     "google-cloud-storage==3.10.1",
     "aioresponses==0.7.8",
-    "toolbox-core[telemetry]"
+    "toolbox-core[telemetry]",
+    "numpy<2", # Pinned to <2 to prevent mypy syntax errors on python 3.10 with numpy 2.x stubs
 ]
 [build-system]
 requires = ["setuptools"]

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -63,7 +63,7 @@ class _McpTransportProxy(ITransport):
 
     def _create_transport(self, protocol: Protocol) -> ITransport:
         match protocol:
-            case Protocol.MCP_v20260618:
+            case Protocol.MCP_DRAFT:
                 return McpHttpTransportV20260618(
                     self._url,
                     self._session,
@@ -187,12 +187,6 @@ class ToolboxClient:
             client_version: Optional client version for identification.
             telemetry_enabled: Whether to enable OpenTelemetry tracing and metrics. (Default: False)
         """
-
-        if protocol != Protocol.MCP_LATEST:
-            logging.warning(
-                f"A newer version of MCP ({Protocol.MCP_LATEST.value}) is available. "
-                "Please use Protocol.MCP_LATEST to use the latest features."
-            )
 
         self.__transport = _McpTransportProxy(
             url,

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -21,6 +21,8 @@ from typing import Any, Awaitable, Callable, Mapping, Optional, Union
 from aiohttp import ClientSession
 from deprecated import deprecated
 
+from toolbox_core.exceptions import ProtocolNegotiationError
+
 from . import version
 from .itransport import ITransport
 from .mcp_transport import (
@@ -28,6 +30,7 @@ from .mcp_transport import (
     McpHttpTransportV20250326,
     McpHttpTransportV20250618,
     McpHttpTransportV20251125,
+    McpHttpTransportV20260618,
 )
 from .protocol import Protocol, ToolSchema
 from .tool import ToolboxTool
@@ -37,6 +40,112 @@ from .utils import (
     validate_unused_requirements,
     warn_if_http_and_headers,
 )
+
+
+class _McpTransportProxy(ITransport):
+    """A proxy transport that transparently handles protocol fallback negotiation."""
+
+    def __init__(
+        self,
+        url: str,
+        session: Optional[ClientSession],
+        protocol: Protocol,
+        client_name: Optional[str],
+        client_version: Optional[str],
+        telemetry_enabled: bool,
+    ):
+        self._url = url
+        self._session = session
+        self._client_name = client_name
+        self._client_version = client_version
+        self._telemetry_enabled = telemetry_enabled
+        self._active_transport = self._create_transport(protocol)
+
+    def _create_transport(self, protocol: Protocol) -> ITransport:
+        match protocol:
+            case Protocol.MCP_v20260618:
+                return McpHttpTransportV20260618(
+                    self._url,
+                    self._session,
+                    protocol,
+                    self._client_name,
+                    self._client_version,
+                    telemetry_enabled=self._telemetry_enabled,
+                )
+            case Protocol.MCP_v20251125:
+                return McpHttpTransportV20251125(
+                    self._url,
+                    self._session,
+                    protocol,
+                    self._client_name,
+                    self._client_version,
+                    telemetry_enabled=self._telemetry_enabled,
+                )
+            case Protocol.MCP_v20250618:
+                return McpHttpTransportV20250618(
+                    self._url,
+                    self._session,
+                    protocol,
+                    self._client_name,
+                    self._client_version,
+                    telemetry_enabled=self._telemetry_enabled,
+                )
+            case Protocol.MCP_v20250326:
+                return McpHttpTransportV20250326(
+                    self._url,
+                    self._session,
+                    protocol,
+                    self._client_name,
+                    self._client_version,
+                    telemetry_enabled=self._telemetry_enabled,
+                )
+            case Protocol.MCP_v20241105:
+                return McpHttpTransportV20241105(
+                    self._url,
+                    self._session,
+                    protocol,
+                    self._client_name,
+                    self._client_version,
+                    telemetry_enabled=self._telemetry_enabled,
+                )
+            case _:
+                raise ValueError(f"Unsupported MCP protocol version: {protocol}")
+
+    @property
+    def base_url(self) -> str:
+        return self._active_transport.base_url
+
+    @property
+    def _protocol_version(self) -> str:
+        # We must expose this for tests asserting the current protocol version.
+        return getattr(self._active_transport, "_protocol_version", "")
+
+    async def _execute_with_fallback(
+        self, method_name: str, *args: Any, **kwargs: Any
+    ) -> Any:
+        try:
+            return await getattr(self._active_transport, method_name)(*args, **kwargs)
+        except ProtocolNegotiationError as e:
+            fallback_protocol = Protocol(e.negotiated_version)
+            logging.warning(
+                f"Protocol fallback required. Switching from "
+                f"{self._protocol_version} to {fallback_protocol.value}"
+            )
+            await self._active_transport.close()
+            self._active_transport = self._create_transport(fallback_protocol)
+            return await getattr(self._active_transport, method_name)(*args, **kwargs)
+
+    async def tool_get(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._execute_with_fallback("tool_get", *args, **kwargs)
+
+    async def tools_list(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._execute_with_fallback("tools_list", *args, **kwargs)
+
+    async def tool_invoke(self, *args: Any, **kwargs: Any) -> Any:
+        return await self._execute_with_fallback("tool_invoke", *args, **kwargs)
+
+    async def close(self) -> None:
+        await self._active_transport.close()
 
 
 class ToolboxClient:
@@ -85,45 +194,14 @@ class ToolboxClient:
                 "Please use Protocol.MCP_LATEST to use the latest features."
             )
 
-        match protocol:
-            case Protocol.MCP_v20251125:
-                self.__transport = McpHttpTransportV20251125(
-                    url,
-                    session,
-                    protocol,
-                    client_name,
-                    client_version,
-                    telemetry_enabled=telemetry_enabled,
-                )
-            case Protocol.MCP_v20250618:
-                self.__transport = McpHttpTransportV20250618(
-                    url,
-                    session,
-                    protocol,
-                    client_name,
-                    client_version,
-                    telemetry_enabled=telemetry_enabled,
-                )
-            case Protocol.MCP_v20250326:
-                self.__transport = McpHttpTransportV20250326(
-                    url,
-                    session,
-                    protocol,
-                    client_name,
-                    client_version,
-                    telemetry_enabled=telemetry_enabled,
-                )
-            case Protocol.MCP_v20241105:
-                self.__transport = McpHttpTransportV20241105(
-                    url,
-                    session,
-                    protocol,
-                    client_name,
-                    client_version,
-                    telemetry_enabled=telemetry_enabled,
-                )
-            case _:
-                raise ValueError(f"Unsupported MCP protocol version: {protocol}")
+        self.__transport = _McpTransportProxy(
+            url,
+            session,
+            protocol,
+            client_name,
+            client_version,
+            telemetry_enabled,
+        )
 
         self.__client_headers = client_headers if client_headers is not None else {}
         warn_if_http_and_headers(url, self.__client_headers)

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -53,12 +53,14 @@ class _McpTransportProxy(ITransport):
         client_name: Optional[str],
         client_version: Optional[str],
         telemetry_enabled: bool,
+        supported_protocols: Optional[list[str]] = None,
     ):
         self._url = url
         self._session = session
         self._client_name = client_name
         self._client_version = client_version
         self._telemetry_enabled = telemetry_enabled
+        self._supported_protocols = supported_protocols
         self._active_transport = self._create_transport(protocol)
 
     def _create_transport(self, protocol: Protocol) -> ITransport:
@@ -71,6 +73,7 @@ class _McpTransportProxy(ITransport):
                     self._client_name,
                     self._client_version,
                     telemetry_enabled=self._telemetry_enabled,
+                    supported_protocols=self._supported_protocols,
                 )
             case Protocol.MCP_v20251125:
                 return McpHttpTransportV20251125(
@@ -80,6 +83,7 @@ class _McpTransportProxy(ITransport):
                     self._client_name,
                     self._client_version,
                     telemetry_enabled=self._telemetry_enabled,
+                    supported_protocols=self._supported_protocols,
                 )
             case Protocol.MCP_v20250618:
                 return McpHttpTransportV20250618(
@@ -89,6 +93,7 @@ class _McpTransportProxy(ITransport):
                     self._client_name,
                     self._client_version,
                     telemetry_enabled=self._telemetry_enabled,
+                    supported_protocols=self._supported_protocols,
                 )
             case Protocol.MCP_v20250326:
                 return McpHttpTransportV20250326(
@@ -98,6 +103,7 @@ class _McpTransportProxy(ITransport):
                     self._client_name,
                     self._client_version,
                     telemetry_enabled=self._telemetry_enabled,
+                    supported_protocols=self._supported_protocols,
                 )
             case Protocol.MCP_v20241105:
                 return McpHttpTransportV20241105(
@@ -107,6 +113,7 @@ class _McpTransportProxy(ITransport):
                     self._client_name,
                     self._client_version,
                     telemetry_enabled=self._telemetry_enabled,
+                    supported_protocols=self._supported_protocols,
                 )
             case _:
                 raise ValueError(f"Unsupported MCP protocol version: {protocol}")
@@ -126,7 +133,35 @@ class _McpTransportProxy(ITransport):
         try:
             return await getattr(self._active_transport, method_name)(*args, **kwargs)
         except ProtocolNegotiationError as e:
-            fallback_protocol = Protocol(e.negotiated_version)
+            server_version = e.negotiated_version
+            all_versions = Protocol.get_supported_mcp_versions()
+
+            try:
+                server_idx = all_versions.index(server_version)
+            except ValueError:
+                raise RuntimeError(
+                    f"Server returned unknown protocol version: {server_version}"
+                )
+
+            # Artificial Array: Server supports this version and all older ones
+            server_supported = all_versions[server_idx:]
+
+            if self._supported_protocols:
+                client_supported = self._supported_protocols
+                mutually_supported = [
+                    v for v in client_supported if v in server_supported
+                ]
+                if mutually_supported:
+                    fallback_protocol = Protocol(mutually_supported[0])
+                else:
+                    raise RuntimeError(
+                        "No mutually supported protocol version. "
+                        f"Client supports: {client_supported}, "
+                        f"Server supports (and older): {server_version}"
+                    )
+            else:
+                fallback_protocol = Protocol(server_version)
+
             logging.warning(
                 f"Protocol fallback required. Switching from "
                 f"{self._protocol_version} to {fallback_protocol.value}"
@@ -166,7 +201,7 @@ class ToolboxClient:
         client_headers: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
         ] = None,
-        protocol: Protocol = Protocol.MCP,
+        protocol: Union[Protocol, list[Protocol], list[str]] = Protocol.MCP,
         client_name: Optional[str] = None,
         client_version: Optional[str] = None,
         telemetry_enabled: bool = False,
@@ -182,19 +217,47 @@ class ToolboxClient:
                 should typically be managed externally.
             client_headers: Headers to include in each request sent through this
             client.
-            protocol: The communication protocol to use.
+            protocol: The communication protocol to use. Can be a single version or a list of versions.
+                If no version is given, the latest version is tried for.
+                If a single version is given, then that version is tried for, followed by newest mutually supported version.
+                If a list of versions is provided (e.g. [Protocol.MCP_LATEST, "2025-11-25"]), negotiation is restricted to those versions, and the newest mutually supported version in that range is tried for.
             client_name: Optional client name for identification.
             client_version: Optional client version for identification.
             telemetry_enabled: Whether to enable OpenTelemetry tracing and metrics. (Default: False)
         """
 
+        if isinstance(protocol, list):
+            if not protocol:
+                raise ValueError("protocol list cannot be empty")
+            user_protocols = [
+                p.value if isinstance(p, Protocol) else str(p) for p in protocol
+            ]
+
+            supported_mcp_versions = Protocol.get_supported_mcp_versions()
+            for p in user_protocols:
+                if p not in supported_mcp_versions:
+                    raise ValueError(
+                        f"Invalid protocol version '{p}'. Must be one of: {supported_mcp_versions}"
+                    )
+
+            user_protocols_set = set(user_protocols)
+            # Intersect with the globally sorted list to strictly enforce newest-to-oldest ordering
+            supported_protocols = [
+                v for v in supported_mcp_versions if v in user_protocols_set
+            ]
+            initial_protocol = Protocol(supported_protocols[0])
+        else:
+            supported_protocols = None
+            initial_protocol = protocol
+
         self.__transport = _McpTransportProxy(
             url,
             session,
-            protocol,
+            initial_protocol,
             client_name,
             client_version,
             telemetry_enabled,
+            supported_protocols,
         )
 
         self.__client_headers = client_headers if client_headers is not None else {}

--- a/packages/toolbox-core/src/toolbox_core/exceptions.py
+++ b/packages/toolbox-core/src/toolbox_core/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .v20241105.mcp import McpHttpTransportV20241105
-from .v20250326.mcp import McpHttpTransportV20250326
-from .v20250618.mcp import McpHttpTransportV20250618
-from .v20251125.mcp import McpHttpTransportV20251125
-from .v20260618.mcp import McpHttpTransportV20260618
 
-__all__ = [
-    "McpHttpTransportV20241105",
-    "McpHttpTransportV20250326",
-    "McpHttpTransportV20250618",
-    "McpHttpTransportV20251125",
-    "McpHttpTransportV20260618",
-]
+class ToolboxError(Exception):
+    """Base exception for all MCP Toolbox errors."""
+
+    pass
+
+
+class ProtocolNegotiationError(ToolboxError):
+    """Raised when the server requires a different protocol version during a stateless request."""
+
+    def __init__(self, negotiated_version: str):
+        self.negotiated_version = negotiated_version
+        super().__init__(f"Server requires protocol fallback to {negotiated_version}")

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -42,6 +42,7 @@ class _McpHttpTransportBase(ITransport, ABC):
         client_name: Optional[str] = None,
         client_version: Optional[str] = None,
         telemetry_enabled: bool = False,
+        supported_protocols: Optional[list[str]] = None,
     ):
         self._mcp_base_url = f"{base_url}/mcp/"
         self._protocol_version = protocol.value
@@ -50,6 +51,9 @@ class _McpHttpTransportBase(ITransport, ABC):
         self._client_name = client_name
         self._client_version = client_version
         self._telemetry_enabled = telemetry.resolve_telemetry_enabled(telemetry_enabled)
+        self._supported_protocols = (
+            supported_protocols or Protocol.get_supported_mcp_versions()
+        )
 
         self._tracer: Optional[telemetry.Tracer] = None
         self._operation_duration_histogram: Optional[telemetry.Histogram] = None

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 
 from ... import version
 from ...exceptions import ProtocolNegotiationError
-from ...protocol import ManifestSchema, TelemetryAttributes
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
 from . import types
@@ -53,27 +53,97 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
         async with self._session.post(
             url, json=payload, headers=dict(headers or {})
         ) as response:
+            json_resp = None
             if not response.ok:
-                error_text = await response.text()
-                raise RuntimeError(
-                    f"API request failed with status {response.status} "
-                    f"({response.reason}). Server response: {error_text}"
-                )
-
-            if response.status == 204 or response.content.at_eof():
-                return None
-
-            json_resp = await response.json()
+                try:
+                    json_resp = await response.json()
+                except Exception:
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        f"API request failed with status {response.status} "
+                        f"({response.reason}). Server response: {error_text}"
+                    )
+            else:
+                if response.status == 204 or response.content.at_eof():
+                    return None
+                json_resp = await response.json()
 
             # Check for JSON-RPC Error
-            if "error" in json_resp:
+            if json_resp and isinstance(json_resp, dict) and "error" in json_resp:
+                err_val = json_resp["error"]
+                if (
+                    isinstance(err_val, dict)
+                    and err_val.get("code")
+                    == types.UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+                ):
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = self._supported_protocols
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
+                elif (
+                    isinstance(err_val, str)
+                    and (
+                        "invalid protocol version" in err_val.lower()
+                        or "unsupported protocol version" in err_val.lower()
+                    )
+                ) or (
+                    isinstance(err_val, dict)
+                    and (
+                        "invalid protocol version"
+                        in str(err_val.get("message", "")).lower()
+                        or "unsupported protocol version"
+                        in str(err_val.get("message", "")).lower()
+                    )
+                ):
+                    client_supported = (
+                        self._supported_protocols
+                        or Protocol.get_supported_mcp_versions()
+                    )
+                    try:
+                        current_idx = client_supported.index(self._protocol_version)
+                        if current_idx + 1 < len(client_supported):
+                            raise ProtocolNegotiationError(
+                                client_supported[current_idx + 1]
+                            )
+                        else:
+                            raise RuntimeError(
+                                "Server threw 'invalid protocol version' but no fallback versions "
+                                "remain in the user's supported protocols array."
+                            )
+                    except ValueError:
+                        raise RuntimeError(
+                            f"Invalid state: current protocol "
+                            f"{self._protocol_version} is not in "
+                            f"supported_protocols."
+                        )
+
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
+                except Exception:
+                    err = None
+
+                if err:
                     raise RuntimeError(
                         f"MCP request failed with code {err.code}: {err.message}"
                     )
-                except Exception:
-                    raise RuntimeError(f"MCP request failed: {json_resp.get('error')}")
+                else:
+                    raw_error = json_resp.get("error", {})
+                    raise RuntimeError(f"MCP request failed: {raw_error}")
+
+            if not response.ok:
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). "
+                    f"Server response: {json_resp}"
+                )
 
             # Parse Result
             if isinstance(request, types.MCPRequest):

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -18,6 +18,7 @@ from typing import Mapping, Optional, TypeVar
 from pydantic import BaseModel
 
 from ... import version
+from ...exceptions import ProtocolNegotiationError
 from ...protocol import ManifestSchema, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
@@ -131,9 +132,7 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    f"MCP version mismatch: client does not support server version {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/types.py
@@ -17,6 +17,8 @@ from typing import Any, Generic, Literal, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
+UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE = -32022
+
 
 class _BaseMCPModel(BaseModel):
     """Base model with common configuration."""

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import time
-from typing import Mapping, Optional, TypeVar
+from typing import Any, Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
 
 from ... import version
+from ...exceptions import ProtocolNegotiationError
 from ...protocol import ManifestSchema, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
@@ -29,7 +30,7 @@ ReceiveResultT = TypeVar("ReceiveResultT", bound=BaseModel)
 class McpHttpTransportV20250326(_McpHttpTransportBase):
     """Transport for the MCP v2025-03-26 protocol."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._session_id: Optional[str] = None
 
@@ -147,10 +148,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    "MCP version mismatch: client does not support server version"
-                    f" {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 
 from ... import version
 from ...exceptions import ProtocolNegotiationError
-from ...protocol import ManifestSchema, TelemetryAttributes
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
 from . import types
@@ -66,30 +66,98 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
             if request.method == "initialize" and "Mcp-Session-Id" in response.headers:
                 self._session_id = response.headers["Mcp-Session-Id"]
 
+            json_resp = None
             if not response.ok:
-                error_text = await response.text()
-                raise RuntimeError(
-                    "API request failed with status"
-                    f" {response.status} ({response.reason}). Server response:"
-                    f" {error_text}"
-                )
-
-            if response.status == 204 or response.content.at_eof():
-                return None
-
-            json_resp = await response.json()
+                try:
+                    json_resp = await response.json()
+                except Exception:
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        "API request failed with status"
+                        f" {response.status} ({response.reason}). Server response:"
+                        f" {error_text}"
+                    )
+            else:
+                if response.status == 204 or response.content.at_eof():
+                    return None
+                json_resp = await response.json()
 
             # Check for JSON-RPC Error
-            if "error" in json_resp:
+            if json_resp and isinstance(json_resp, dict) and "error" in json_resp:
+                err_val = json_resp["error"]
+                if (
+                    isinstance(err_val, dict)
+                    and err_val.get("code")
+                    == types.UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+                ):
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = self._supported_protocols
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
+                elif (
+                    isinstance(err_val, str)
+                    and (
+                        "invalid protocol version" in err_val.lower()
+                        or "unsupported protocol version" in err_val.lower()
+                    )
+                ) or (
+                    isinstance(err_val, dict)
+                    and (
+                        "invalid protocol version"
+                        in str(err_val.get("message", "")).lower()
+                        or "unsupported protocol version"
+                        in str(err_val.get("message", "")).lower()
+                    )
+                ):
+                    client_supported = (
+                        self._supported_protocols
+                        or Protocol.get_supported_mcp_versions()
+                    )
+                    try:
+                        current_idx = client_supported.index(self._protocol_version)
+                        if current_idx + 1 < len(client_supported):
+                            raise ProtocolNegotiationError(
+                                client_supported[current_idx + 1]
+                            )
+                        else:
+                            raise RuntimeError(
+                                "Server threw 'invalid protocol version' but no fallback versions "
+                                "remain in the user's supported protocols array."
+                            )
+                    except ValueError:
+                        raise RuntimeError(
+                            f"Invalid state: current protocol "
+                            f"{self._protocol_version} is not in "
+                            f"supported_protocols."
+                        )
+
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
+                except Exception:
+                    err = None
+
+                if err:
                     raise RuntimeError(
                         f"MCP request failed with code {err.code}: {err.message}"
                     )
-                except Exception:
-                    # Fallback if the error doesn't match our schema exactly
+                else:
                     raw_error = json_resp.get("error", {})
                     raise RuntimeError(f"MCP request failed: {raw_error}")
+
+            if not response.ok:
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). "
+                    f"Server response: {json_resp}"
+                )
 
             # Parse Result
             if isinstance(request, types.MCPRequest):

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/types.py
@@ -17,6 +17,8 @@ from typing import Any, Generic, Literal, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
+UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE = -32022
+
 
 class _BaseMCPModel(BaseModel):
     """Base model with common configuration."""

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -18,7 +18,8 @@ from typing import Mapping, Optional, TypeVar
 from pydantic import BaseModel
 
 from ... import version
-from ...protocol import ManifestSchema, TelemetryAttributes
+from ...exceptions import ProtocolNegotiationError
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
 from . import types
@@ -71,6 +72,21 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
 
             # Check for JSON-RPC Error
             if "error" in json_resp:
+                err_val = json_resp["error"]
+                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = Protocol.get_supported_mcp_versions()
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
                     raise RuntimeError(
@@ -138,10 +154,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    "MCP version mismatch: client does not support server version"
-                    f" {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -57,25 +57,32 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
         async with self._session.post(
             url, json=payload, headers=req_headers
         ) as response:
+            json_resp = None
             if not response.ok:
-                error_text = await response.text()
-                raise RuntimeError(
-                    "API request failed with status"
-                    f" {response.status} ({response.reason}). Server response:"
-                    f" {error_text}"
-                )
-
-            if response.status == 204 or response.content.at_eof():
-                return None
-
-            json_resp = await response.json()
+                try:
+                    json_resp = await response.json()
+                except Exception:
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        "API request failed with status"
+                        f" {response.status} ({response.reason}). Server response:"
+                        f" {error_text}"
+                    )
+            else:
+                if response.status == 204 or response.content.at_eof():
+                    return None
+                json_resp = await response.json()
 
             # Check for JSON-RPC Error
-            if "error" in json_resp:
+            if json_resp and isinstance(json_resp, dict) and "error" in json_resp:
                 err_val = json_resp["error"]
-                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                if (
+                    isinstance(err_val, dict)
+                    and err_val.get("code")
+                    == types.UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+                ):
                     server_supported = err_val.get("data", {}).get("supported", [])
-                    client_supported = Protocol.get_supported_mcp_versions()
+                    client_supported = self._supported_protocols
                     mutually_supported = [
                         v for v in client_supported if v in server_supported
                     ]
@@ -87,15 +94,61 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
                             f"Client supports: {client_supported}, "
                             f"Server supports: {server_supported}"
                         )
+                elif (
+                    isinstance(err_val, str)
+                    and (
+                        "invalid protocol version" in err_val.lower()
+                        or "unsupported protocol version" in err_val.lower()
+                    )
+                ) or (
+                    isinstance(err_val, dict)
+                    and (
+                        "invalid protocol version"
+                        in str(err_val.get("message", "")).lower()
+                        or "unsupported protocol version"
+                        in str(err_val.get("message", "")).lower()
+                    )
+                ):
+                    client_supported = (
+                        self._supported_protocols
+                        or Protocol.get_supported_mcp_versions()
+                    )
+                    try:
+                        current_idx = client_supported.index(self._protocol_version)
+                        if current_idx + 1 < len(client_supported):
+                            raise ProtocolNegotiationError(
+                                client_supported[current_idx + 1]
+                            )
+                        else:
+                            raise RuntimeError(
+                                "Server threw 'invalid protocol version' but no fallback versions "
+                                "remain in the user's supported protocols array."
+                            )
+                    except ValueError:
+                        raise RuntimeError(
+                            f"Invalid state: current protocol "
+                            f"{self._protocol_version} is not in "
+                            f"supported_protocols."
+                        )
+
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
+                except Exception:
+                    err = None
+
+                if err:
                     raise RuntimeError(
                         f"MCP request failed with code {err.code}: {err.message}"
                     )
-                except Exception:
-                    # Fallback if the error doesn't match our schema exactly
+                else:
                     raw_error = json_resp.get("error", {})
                     raise RuntimeError(f"MCP request failed: {raw_error}")
+
+            if not response.ok:
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). "
+                    f"Server response: {json_resp}"
+                )
 
             # Parse Result
             if isinstance(request, types.MCPRequest):

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/types.py
@@ -17,6 +17,8 @@ from typing import Any, Generic, Literal, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
+UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE = -32022
+
 
 class _BaseMCPModel(BaseModel):
     """Base model with common configuration."""

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
@@ -57,25 +57,32 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
         async with self._session.post(
             url, json=payload, headers=req_headers
         ) as response:
+            json_resp = None
             if not response.ok:
-                error_text = await response.text()
-                raise RuntimeError(
-                    "API request failed with status"
-                    f" {response.status} ({response.reason}). Server response:"
-                    f" {error_text}"
-                )
-
-            if response.status == 204 or response.content.at_eof():
-                return None
-
-            json_resp = await response.json()
+                try:
+                    json_resp = await response.json()
+                except Exception:
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        "API request failed with status"
+                        f" {response.status} ({response.reason}). Server response:"
+                        f" {error_text}"
+                    )
+            else:
+                if response.status == 204 or response.content.at_eof():
+                    return None
+                json_resp = await response.json()
 
             # Check for JSON-RPC Error
-            if "error" in json_resp:
+            if json_resp and isinstance(json_resp, dict) and "error" in json_resp:
                 err_val = json_resp["error"]
-                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                if (
+                    isinstance(err_val, dict)
+                    and err_val.get("code")
+                    == types.UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+                ):
                     server_supported = err_val.get("data", {}).get("supported", [])
-                    client_supported = Protocol.get_supported_mcp_versions()
+                    client_supported = self._supported_protocols
                     mutually_supported = [
                         v for v in client_supported if v in server_supported
                     ]
@@ -87,15 +94,61 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
                             f"Client supports: {client_supported}, "
                             f"Server supports: {server_supported}"
                         )
+                elif (
+                    isinstance(err_val, str)
+                    and (
+                        "invalid protocol version" in err_val.lower()
+                        or "unsupported protocol version" in err_val.lower()
+                    )
+                ) or (
+                    isinstance(err_val, dict)
+                    and (
+                        "invalid protocol version"
+                        in str(err_val.get("message", "")).lower()
+                        or "unsupported protocol version"
+                        in str(err_val.get("message", "")).lower()
+                    )
+                ):
+                    client_supported = (
+                        self._supported_protocols
+                        or Protocol.get_supported_mcp_versions()
+                    )
+                    try:
+                        current_idx = client_supported.index(self._protocol_version)
+                        if current_idx + 1 < len(client_supported):
+                            raise ProtocolNegotiationError(
+                                client_supported[current_idx + 1]
+                            )
+                        else:
+                            raise RuntimeError(
+                                "Server threw 'invalid protocol version' but no fallback versions "
+                                "remain in the user's supported protocols array."
+                            )
+                    except ValueError:
+                        raise RuntimeError(
+                            f"Invalid state: current protocol "
+                            f"{self._protocol_version} is not in "
+                            f"supported_protocols."
+                        )
+
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
+                except Exception:
+                    err = None
+
+                if err:
                     raise RuntimeError(
                         f"MCP request failed with code {err.code}: {err.message}"
                     )
-                except Exception:
-                    # Fallback if the error doesn't match our schema exactly
+                else:
                     raw_error = json_resp.get("error", {})
                     raise RuntimeError(f"MCP request failed: {raw_error}")
+
+            if not response.ok:
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). "
+                    f"Server response: {json_resp}"
+                )
 
             # Parse Result
             if isinstance(request, types.MCPRequest):

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
@@ -18,7 +18,8 @@ from typing import Mapping, Optional, TypeVar
 from pydantic import BaseModel
 
 from ... import version
-from ...protocol import ManifestSchema, TelemetryAttributes
+from ...exceptions import ProtocolNegotiationError
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
 from . import types
@@ -71,6 +72,21 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
 
             # Check for JSON-RPC Error
             if "error" in json_resp:
+                err_val = json_resp["error"]
+                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = Protocol.get_supported_mcp_versions()
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
                     raise RuntimeError(
@@ -138,10 +154,7 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    "MCP version mismatch: client does not support server version"
-                    f" {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/types.py
@@ -17,6 +17,8 @@ from typing import Any, Generic, Literal, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
+UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE = -32022
+
 
 class _BaseMCPModel(BaseModel):
     """Base model with common configuration."""

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -40,6 +40,16 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
         req_headers = dict(headers or {})
         req_headers["MCP-Protocol-Version"] = self._protocol_version
 
+        # Inject SEP-2243 routing headers
+        req_headers["Mcp-Method"] = request.method
+        if (
+            request.method == "tools/call"
+            and hasattr(request, "params")
+            and request.params is not None
+        ):
+            if hasattr(request.params, "name"):
+                req_headers["Mcp-Name"] = request.params.name
+
         # Dynamically update the _meta protocol version in the parameters model
         if hasattr(request, "params") and request.params is not None:
             if (

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -42,13 +42,16 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
 
         # Inject SEP-2243 routing headers
         req_headers["Mcp-Method"] = request.method
-        if (
-            request.method == "tools/call"
-            and hasattr(request, "params")
-            and request.params is not None
-        ):
-            if hasattr(request.params, "name"):
-                req_headers["Mcp-Name"] = request.params.name
+        params = getattr(request, "params", None)
+        if params is not None:
+            if request.method in ("tools/call", "prompts/get"):
+                name = getattr(params, "name", None)
+                if name is not None:
+                    req_headers["Mcp-Name"] = str(name)
+            elif request.method == "resources/read":
+                uri = getattr(params, "uri", None)
+                if uri is not None:
+                    req_headers["Mcp-Name"] = str(uri)
 
         # Dynamically update the _meta protocol version in the parameters model
         if hasattr(request, "params") and request.params is not None:
@@ -125,6 +128,21 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
 
             # Check for JSON-RPC Error
             if "error" in json_resp:
+                err_val = json_resp["error"]
+                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = Protocol.get_supported_mcp_versions()
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
                     raise RuntimeError(

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -78,60 +78,36 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
         async with self._session.post(
             url, json=payload, headers=req_headers
         ) as response:
-            if response.status == 400:
+            json_resp = None
+            if not response.ok:
                 try:
                     json_resp = await response.json()
-                    if "error" in json_resp:
-                        err_val = json_resp["error"]
-                        if isinstance(err_val, dict) and err_val.get("code") == -32004:
-                            server_supported = err_val.get("data", {}).get(
-                                "supported", []
-                            )
-
-                            client_supported = Protocol.get_supported_mcp_versions()
-                            mutually_supported = [
-                                v for v in client_supported if v in server_supported
-                            ]
-
-                            if mutually_supported:
-                                raise ProtocolNegotiationError(mutually_supported[0])
-                            else:
-                                raise RuntimeError(
-                                    "No mutually supported protocol version. "
-                                    f"Client supports: {client_supported}, "
-                                    f"Server supports: {server_supported}"
-                                )
-                        elif (
-                            isinstance(err_val, str)
-                            and "invalid protocol version" in err_val.lower()
-                        ):
-                            # Legacy 2025-06-18 servers don't use the -32004 code or provide
-                            # a supported versions list. They return this raw string error
-                            # instead. We safely assume 2025-06-18 here.
-                            raise ProtocolNegotiationError(Protocol.MCP_v20250618)
-                except Exception as e:
-                    if isinstance(e, (RuntimeError, ProtocolNegotiationError)):
-                        raise e
-
-            if not response.ok:
-                error_text = await response.text()
-                raise RuntimeError(
-                    "API request failed with status"
-                    f" {response.status} ({response.reason}). Server response:"
-                    f" {error_text}"
-                )
-
-            if response.status == 204 or response.content.at_eof():
-                return None
-
-            json_resp = await response.json()
+                except Exception:
+                    # Not JSON, fallback to raw text
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        "API request failed with status"
+                        f" {response.status} ({response.reason}). Server response:"
+                        f" {error_text}"
+                    )
+            else:
+                if response.status == 204 or response.content.at_eof():
+                    return None
+                json_resp = await response.json()
 
             # Check for JSON-RPC Error
-            if "error" in json_resp:
+            if json_resp and isinstance(json_resp, dict) and "error" in json_resp:
                 err_val = json_resp["error"]
-                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                if (
+                    isinstance(err_val, dict)
+                    and err_val.get("code")
+                    == types.UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+                ):
                     server_supported = err_val.get("data", {}).get("supported", [])
-                    client_supported = Protocol.get_supported_mcp_versions()
+                    client_supported = (
+                        self._supported_protocols
+                        or Protocol.get_supported_mcp_versions()
+                    )
                     mutually_supported = [
                         v for v in client_supported if v in server_supported
                     ]
@@ -143,15 +119,64 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
                             f"Client supports: {client_supported}, "
                             f"Server supports: {server_supported}"
                         )
+                elif (
+                    isinstance(err_val, str)
+                    and (
+                        "invalid protocol version" in err_val.lower()
+                        or "unsupported protocol version" in err_val.lower()
+                    )
+                ) or (
+                    isinstance(err_val, dict)
+                    and (
+                        "invalid protocol version"
+                        in str(err_val.get("message", "")).lower()
+                        or "unsupported protocol version"
+                        in str(err_val.get("message", "")).lower()
+                    )
+                ):
+                    # Cascading Fallback: Legacy servers throw this string error.
+                    # We pick the next version from the user's supported list.
+                    client_supported = (
+                        self._supported_protocols
+                        or Protocol.get_supported_mcp_versions()
+                    )
+                    try:
+                        current_idx = client_supported.index(self._protocol_version)
+                        if current_idx + 1 < len(client_supported):
+                            raise ProtocolNegotiationError(
+                                client_supported[current_idx + 1]
+                            )
+                        else:
+                            raise RuntimeError(
+                                "Server threw 'invalid protocol version' but no fallback versions "
+                                "remain in the user's supported protocols array."
+                            )
+                    except ValueError:
+                        raise RuntimeError(
+                            f"Invalid state: current protocol "
+                            f"{self._protocol_version} is not in "
+                            f"supported_protocols."
+                        )
+
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
+                except Exception:
+                    err = None
+
+                if err:
                     raise RuntimeError(
                         f"MCP request failed with code {err.code}: {err.message}"
                     )
-                except Exception:
-                    # Fallback if the error doesn't match our schema exactly
+                else:
                     raw_error = json_resp.get("error", {})
                     raise RuntimeError(f"MCP request failed: {raw_error}")
+
+            # If response.ok was False, but there was no JSON-RPC "error" field
+            if not response.ok:
+                raise RuntimeError(
+                    f"API request failed with status {response.status} ({response.reason}). "
+                    f"Server response: {json_resp}"
+                )
 
             # Parse Result
             if isinstance(request, types.MCPRequest):

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -1,0 +1,297 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from typing import Mapping, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from ... import version
+from ...exceptions import ProtocolNegotiationError
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
+from .. import telemetry
+from ..transport_base import _McpHttpTransportBase
+from . import types
+
+ReceiveResultT = TypeVar("ReceiveResultT", bound=BaseModel)
+
+
+class McpHttpTransportV20260618(_McpHttpTransportBase):
+    """Transport for the MCP draft Request-Metadata (v2026-06-18) protocol."""
+
+    async def _send_request(
+        self,
+        url: str,
+        request: types.MCPRequest[ReceiveResultT] | types.MCPNotification,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> ReceiveResultT | None:
+        """Sends a JSON-RPC request to the MCP server."""
+        req_headers = dict(headers or {})
+        req_headers["MCP-Protocol-Version"] = self._protocol_version
+
+        # Dynamically update the _meta protocol version in the parameters model
+        if hasattr(request, "params") and request.params is not None:
+            if (
+                hasattr(request.params, "field_meta")
+                and request.params.field_meta is not None
+            ):
+                request.params.field_meta.protocol_version = self._protocol_version
+
+        params = (
+            request.params.model_dump(mode="json", exclude_none=True, by_alias=True)
+            if isinstance(request.params, BaseModel)
+            else request.params
+        )
+
+        rpc_msg: BaseModel
+        if isinstance(request, types.MCPNotification):
+            rpc_msg = types.JSONRPCNotification(method=request.method, params=params)
+        else:
+            rpc_msg = types.JSONRPCRequest(method=request.method, params=params)
+
+        payload = rpc_msg.model_dump(mode="json", exclude_none=True)
+
+        async with self._session.post(
+            url, json=payload, headers=req_headers
+        ) as response:
+            if response.status == 400:
+                try:
+                    json_resp = await response.json()
+                    if "error" in json_resp:
+                        err_val = json_resp["error"]
+                        if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                            server_supported = err_val.get("data", {}).get(
+                                "supported", []
+                            )
+
+                            client_supported = Protocol.get_supported_mcp_versions()
+                            mutually_supported = [
+                                v for v in client_supported if v in server_supported
+                            ]
+
+                            if mutually_supported:
+                                raise ProtocolNegotiationError(mutually_supported[0])
+                            else:
+                                raise RuntimeError(
+                                    "No mutually supported protocol version. "
+                                    f"Client supports: {client_supported}, "
+                                    f"Server supports: {server_supported}"
+                                )
+                        elif (
+                            isinstance(err_val, str)
+                            and "invalid protocol version" in err_val.lower()
+                        ):
+                            # Legacy 2025-06-18 servers don't use the -32004 code or provide
+                            # a supported versions list. They return this raw string error
+                            # instead. We safely assume 2025-06-18 here.
+                            raise ProtocolNegotiationError(Protocol.MCP_v20250618)
+                except Exception as e:
+                    if isinstance(e, (RuntimeError, ProtocolNegotiationError)):
+                        raise e
+
+            if not response.ok:
+                error_text = await response.text()
+                raise RuntimeError(
+                    "API request failed with status"
+                    f" {response.status} ({response.reason}). Server response:"
+                    f" {error_text}"
+                )
+
+            if response.status == 204 or response.content.at_eof():
+                return None
+
+            json_resp = await response.json()
+
+            # Check for JSON-RPC Error
+            if "error" in json_resp:
+                try:
+                    err = types.JSONRPCError.model_validate(json_resp).error
+                    raise RuntimeError(
+                        f"MCP request failed with code {err.code}: {err.message}"
+                    )
+                except Exception:
+                    # Fallback if the error doesn't match our schema exactly
+                    raw_error = json_resp.get("error", {})
+                    raise RuntimeError(f"MCP request failed: {raw_error}")
+
+            # Parse Result
+            if isinstance(request, types.MCPRequest):
+                try:
+                    rpc_resp = types.JSONRPCResponse.model_validate(json_resp)
+                    return request.get_result_model().model_validate(rpc_resp.result)
+                except Exception as e:
+                    raise RuntimeError(f"Failed to parse JSON-RPC response: {e}")
+            return None
+
+    async def _initialize_session(
+        self, headers: Optional[Mapping[str, str]] = None
+    ) -> None:
+        """No-op for stateless transport since there is no session handshake."""
+        pass
+
+    async def tools_list(
+        self,
+        toolset_name: Optional[str] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> ManifestSchema:
+        """Lists available tools from the server using the MCP protocol."""
+        await self._ensure_initialized(headers=headers)
+
+        url = self._mcp_base_url + (toolset_name if toolset_name else "")
+
+        meta = types.MCPMeta(
+            protocol_version=self._protocol_version,
+            client_info=types.Implementation(
+                name=self._client_name or "toolbox-core-python",
+                version=self._client_version or version.__version__,
+            ),
+            client_capabilities=types.ClientCapabilities(),
+        )
+
+        if self._telemetry_enabled:
+            operation_start = time.time()
+            span, traceparent, tracestate = telemetry.start_span(
+                self._tracer,
+                "tools/list",
+                self._protocol_version,
+                url,
+                network_transport="tcp",
+            )
+            if span is not None:
+                meta.traceparent = traceparent or None
+                meta.tracestate = tracestate or None
+
+        error: Optional[Exception] = None
+        try:
+            result = await self._send_request(
+                url=url,
+                request=types.ListToolsRequest(
+                    params=types.ListToolsRequestParams(field_meta=meta)
+                ),
+                headers=headers,
+            )
+            if result is None:
+                raise RuntimeError("Failed to list tools: No response from server.")
+
+            tools_map = {t["name"]: self._convert_tool_schema(t) for t in result.tools}
+
+            return ManifestSchema(
+                serverVersion="1.0.0",
+                tools=tools_map,
+            )
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if self._telemetry_enabled:
+                operation_duration = time.time() - operation_start
+                telemetry.record_operation_duration(
+                    self._operation_duration_histogram,
+                    operation_duration,
+                    "tools/list",
+                    self._protocol_version,
+                    url,
+                    network_transport="tcp",
+                    error=error,
+                )
+                telemetry.end_span(span, error=error)
+
+    async def tool_get(
+        self, tool_name: str, headers: Optional[Mapping[str, str]] = None
+    ) -> ManifestSchema:
+        """Gets a single tool from the server by listing all and filtering."""
+        manifest = await self.tools_list(headers=headers)
+
+        if tool_name not in manifest.tools:
+            raise ValueError(f"Tool '{tool_name}' not found.")
+
+        return ManifestSchema(
+            serverVersion=manifest.serverVersion,
+            tools={tool_name: manifest.tools[tool_name]},
+        )
+
+    async def tool_invoke(
+        self,
+        tool_name: str,
+        arguments: dict,
+        headers: Optional[Mapping[str, str]],
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
+    ) -> str:
+        """Invokes a specific tool on the server using the MCP protocol."""
+        await self._ensure_initialized(headers=headers)
+
+        payload = self._build_telemetry_payload(telemetry_attributes)
+
+        meta = types.MCPMeta(
+            protocol_version=self._protocol_version,
+            client_info=types.Implementation(
+                name=self._client_name or "toolbox-core-python",
+                version=self._client_version or version.__version__,
+            ),
+            client_capabilities=types.ClientCapabilities(),
+            telemetry_attributes=payload,
+        )
+
+        span = None
+        if self._telemetry_enabled:
+            operation_start = time.time()
+            span, traceparent, tracestate = telemetry.start_span(
+                self._tracer,
+                "tools/call",
+                self._protocol_version,
+                self._mcp_base_url,
+                tool_name=tool_name,
+                network_transport="tcp",
+            )
+            meta.traceparent = traceparent or None
+            meta.tracestate = tracestate or None
+            if span is not None and payload:
+                for key, value in payload.items():
+                    span.set_attribute(key, value)
+
+        error: Optional[Exception] = None
+        try:
+            result = await self._send_request(
+                url=self._mcp_base_url,
+                request=types.CallToolRequest(
+                    params=types.CallToolRequestParams(
+                        name=tool_name, arguments=arguments, field_meta=meta
+                    )
+                ),
+                headers=headers,
+            )
+
+            if result is None:
+                raise RuntimeError(
+                    f"Failed to invoke tool '{tool_name}': No response from server."
+                )
+
+            return self._process_tool_result_content(result.content)
+        except Exception as e:
+            error = e
+            raise
+        finally:
+            if self._telemetry_enabled:
+                operation_duration = time.time() - operation_start
+                telemetry.record_operation_duration(
+                    self._operation_duration_histogram,
+                    operation_duration,
+                    "tools/call",
+                    self._protocol_version,
+                    self._mcp_base_url,
+                    tool_name=tool_name,
+                    network_transport="tcp",
+                    error=error,
+                )
+                telemetry.end_span(span, error=error)

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/types.py
@@ -17,6 +17,8 @@ from typing import Any, Generic, Literal, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
+UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE = -32022
+
 
 class _BaseMCPModel(BaseModel):
     """Base model with common configuration."""

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/types.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from typing import Any, Generic, Literal, Type, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _BaseMCPModel(BaseModel):
+    """Base model with common configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class JSONRPCRequest(_BaseMCPModel):
+    jsonrpc: Literal["2.0"] = "2.0"
+    id: str | int = Field(default_factory=lambda: str(uuid.uuid4()))
+    method: str
+    params: dict[str, Any] | None = None
+
+
+class JSONRPCNotification(_BaseMCPModel):
+    """A notification which does not expect a response (no ID)."""
+
+    jsonrpc: Literal["2.0"] = "2.0"
+    method: str
+    params: dict[str, Any] | None = None
+
+
+class JSONRPCResponse(_BaseMCPModel):
+    jsonrpc: Literal["2.0"]
+    id: str | int
+    result: dict[str, Any]
+
+
+class ErrorData(_BaseMCPModel):
+    code: int
+    message: str
+    data: Any | None = None
+
+
+class JSONRPCError(_BaseMCPModel):
+    jsonrpc: Literal["2.0"]
+    id: str | int
+    error: ErrorData
+
+
+class SamplingCapabilities(_BaseMCPModel):
+    context: dict[str, Any] | None = None
+    tools: dict[str, Any] | None = None
+
+
+class ElicitationCapabilities(_BaseMCPModel):
+    form: dict[str, Any] | None = None
+    url: dict[str, Any] | None = None
+
+
+class ClientCapabilities(_BaseMCPModel):
+    experimental: dict[str, Any] | None = None
+    roots: dict[str, Any] | None = None
+    sampling: SamplingCapabilities | None = None
+    elicitation: ElicitationCapabilities | None = None
+    extensions: dict[str, Any] | None = None
+
+
+class Implementation(_BaseMCPModel):
+    name: str
+    version: str
+
+
+class MCPMeta(_BaseMCPModel):
+    """Metadata for MCP requests.
+
+    Carries the three required fields in io.modelcontextprotocol/* namespace.
+    """
+
+    protocol_version: str = Field(
+        ..., serialization_alias="io.modelcontextprotocol/protocolVersion"
+    )
+    client_info: Implementation = Field(
+        ..., serialization_alias="io.modelcontextprotocol/clientInfo"
+    )
+    client_capabilities: ClientCapabilities = Field(
+        ..., serialization_alias="io.modelcontextprotocol/clientCapabilities"
+    )
+
+    # Tracing and attributes
+    traceparent: str | None = None
+    tracestate: str | None = None
+    telemetry_attributes: dict[str, Any] | None = Field(
+        default=None, serialization_alias="dev.mcp-toolbox/telemetry"
+    )
+
+
+class ListToolsResult(_BaseMCPModel):
+    tools: list[dict[str, Any]]
+
+
+class TextContent(_BaseMCPModel):
+    type: Literal["text"]
+    text: str
+
+
+class CallToolResult(_BaseMCPModel):
+    content: list[TextContent]
+    isError: bool = False
+
+
+ResultT = TypeVar("ResultT", bound=BaseModel)
+
+
+class MCPRequest(_BaseMCPModel, Generic[ResultT]):
+    method: str
+    params: dict[str, Any] | BaseModel | None = None
+
+    def get_result_model(self) -> Type[ResultT]:
+        raise NotImplementedError
+
+
+class MCPNotification(_BaseMCPModel):
+    method: str
+    params: dict[str, Any] | BaseModel | None = None
+
+
+class ListToolsRequestParams(_BaseMCPModel):
+    field_meta: MCPMeta = Field(..., serialization_alias="_meta")
+
+
+class ListToolsRequest(MCPRequest[ListToolsResult]):
+    method: Literal["tools/list"] = "tools/list"
+    params: ListToolsRequestParams
+
+    def get_result_model(self) -> Type[ListToolsResult]:
+        return ListToolsResult
+
+
+class CallToolRequestParams(_BaseMCPModel):
+    name: str
+    arguments: dict[str, Any]
+    field_meta: MCPMeta = Field(..., serialization_alias="_meta")
+
+
+class CallToolRequest(MCPRequest[CallToolResult]):
+    method: Literal["tools/call"] = "tools/call"
+    params: CallToolRequestParams
+
+    def get_result_model(self) -> Type[CallToolResult]:
+        return CallToolResult

--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -47,17 +47,19 @@ class TelemetryAttributes(BaseModel):
 class Protocol(str, Enum):
     """Defines how the client should choose between communication protocols."""
 
+    MCP_v20260618 = "DRAFT-2026-v1"
     MCP_v20250618 = "2025-06-18"
     MCP_v20250326 = "2025-03-26"
     MCP_v20241105 = "2024-11-05"
     MCP_v20251125 = "2025-11-25"
     MCP = MCP_v20250618
-    MCP_LATEST = MCP_v20251125
+    MCP_LATEST = MCP_v20260618
 
     @staticmethod
     def get_supported_mcp_versions() -> list[str]:
         """Returns a list of supported MCP protocol versions."""
         return [
+            Protocol.MCP_v20260618.value,
             Protocol.MCP_v20251125.value,
             Protocol.MCP_v20250618.value,
             Protocol.MCP_v20250326.value,

--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -47,19 +47,21 @@ class TelemetryAttributes(BaseModel):
 class Protocol(str, Enum):
     """Defines how the client should choose between communication protocols."""
 
-    MCP_v20260618 = "DRAFT-2026-v1"
     MCP_v20250618 = "2025-06-18"
     MCP_v20250326 = "2025-03-26"
     MCP_v20241105 = "2024-11-05"
     MCP_v20251125 = "2025-11-25"
-    MCP = MCP_v20250618
-    MCP_LATEST = MCP_v20260618
+    MCP_v2026_DRAFT = "DRAFT-2026-v1"
+
+    MCP = MCP_v20251125
+    MCP_LATEST = MCP_v20251125
+    MCP_DRAFT = MCP_v2026_DRAFT
 
     @staticmethod
     def get_supported_mcp_versions() -> list[str]:
         """Returns a list of supported MCP protocol versions."""
         return [
-            Protocol.MCP_v20260618.value,
+            Protocol.MCP_DRAFT.value,
             Protocol.MCP_v20251125.value,
             Protocol.MCP_v20250618.value,
             Protocol.MCP_v20250326.value,

--- a/packages/toolbox-core/src/toolbox_core/sync_client.py
+++ b/packages/toolbox-core/src/toolbox_core/sync_client.py
@@ -42,7 +42,7 @@ class ToolboxSyncClient:
         client_headers: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
         ] = None,
-        protocol: Protocol = Protocol.MCP,
+        protocol: Union[Protocol, list[Protocol], list[str]] = Protocol.MCP,
         client_name: Optional[str] = None,
         client_version: Optional[str] = None,
         telemetry_enabled: bool = False,
@@ -53,7 +53,10 @@ class ToolboxSyncClient:
         Args:
             url: The base URL for the Toolbox service API (e.g., "http://localhost:5000").
             client_headers: Headers to include in each request sent through this client.
-            protocol: The communication protocol to use.
+            protocol: The communication protocol to use. Can be a single version or a list of versions.
+                If no version is given, the latest version is tried for.
+                If a single version is given, then that version is tried for, followed by newest mutually supported version.
+                If a list of versions is provided (e.g. [Protocol.MCP_LATEST, "2025-11-25"]), negotiation is restricted to those versions, and the newest mutually supported version in that range is tried for.
             client_name: Optional client name for identification.
             client_version: Optional client version for identification.
             telemetry_enabled: Whether to enable OpenTelemetry tracing and metrics. (Default: False)

--- a/packages/toolbox-core/tests/conformance/client.py
+++ b/packages/toolbox-core/tests/conformance/client.py
@@ -50,7 +50,7 @@ async def main():
 
     protocol = Protocol.MCP
     if scenario == "request-metadata":
-        protocol = Protocol.MCP_v20260618
+        protocol = Protocol.MCP_LATEST
 
     async with ToolboxClient(
         server_url, client_headers=client_headers, protocol=protocol

--- a/packages/toolbox-core/tests/conformance/client.py
+++ b/packages/toolbox-core/tests/conformance/client.py
@@ -18,9 +18,16 @@ import os
 import sys
 
 from toolbox_core.client import ToolboxClient
+from toolbox_core.protocol import Protocol
 
 
 async def main():
+    """Harness main execution block.
+
+    NOTE: All non-protocol outputs (logs, traces, errors) must be directed to
+    sys.stderr. The test runner captures stdout for protocol messages only,
+    printing other content to stdout will pollute the stream and crash the runner.
+    """
     if len(sys.argv) < 2:
         print("Usage: client.py <server_url>", file=sys.stderr)
         sys.exit(1)
@@ -41,7 +48,13 @@ async def main():
 
     client_headers = {"Accept": "application/json, text/event-stream"}
 
-    async with ToolboxClient(server_url, client_headers=client_headers) as client:
+    protocol = Protocol.MCP
+    if scenario == "request-metadata":
+        protocol = Protocol.MCP_v20260618
+
+    async with ToolboxClient(
+        server_url, client_headers=client_headers, protocol=protocol
+    ) as client:
         if scenario == "initialize":
             await client.load_toolset()
             print("Client initialization test completed", file=sys.stderr)
@@ -50,6 +63,10 @@ async def main():
             add_numbers = await client.load_tool("add_numbers")
             await add_numbers(a=1, b=2)
             print("Invoked add_numbers(a=1, b=2)", file=sys.stderr)
+
+        elif scenario == "request-metadata":
+            await client.load_toolset()
+            print("Client request-metadata test completed", file=sys.stderr)
 
         else:
             # Default behavior: load default toolset to trigger standard interactions

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -25,9 +25,12 @@ import time
 from typing import Generator
 
 import google
-import pytest_asyncio
+import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
 
 
 #### Define Utility Functions
@@ -92,17 +95,17 @@ def get_auth_token(client_id: str) -> str:
 
 
 #### Define Fixtures
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def project_id() -> str:
     return get_env_var("GOOGLE_CLOUD_PROJECT")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_version() -> str:
     return get_env_var("TOOLBOX_VERSION")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def tools_file_path(project_id: str) -> Generator[str]:
     """Provides a temporary file path containing the tools manifest."""
     tools_manifest = access_secret_version(
@@ -115,7 +118,7 @@ def tools_file_path(project_id: str) -> Generator[str]:
     os.remove(tools_file_path)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token1(project_id: str) -> str:
     client_id = access_secret_version(
         project_id=project_id, secret_id="sdk_testing_client1"
@@ -123,7 +126,7 @@ def auth_token1(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token2(project_id: str) -> str:
     client_id = access_secret_version(
         project_id=project_id, secret_id="sdk_testing_client2"
@@ -131,7 +134,7 @@ def auth_token2(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None]:
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
@@ -143,20 +146,30 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
         # Make toolbox executable
         os.chmod("toolbox", 0o700)
         # Run toolbox binary
-        toolbox_server = subprocess.Popen(
-            ["./toolbox", "--tools-file", tools_file_path]
+        toolbox_server_1 = subprocess.Popen(
+            ["./toolbox", "--port", "5000", "--tools-file", tools_file_path]
+        )
+        toolbox_server_2 = subprocess.Popen(
+            [
+                "./toolbox",
+                "--port",
+                "5001",
+                "--tools-file",
+                tools_file_path,
+                "--enable-draft-specs",
+            ]
         )
 
         # Wait for server to start
         # Retry logic with a timeout
         for _ in range(5):  # retries
             time.sleep(2)
-            print("Checking if toolbox is successfully started...")
-            if toolbox_server.poll() is None:
-                print("Toolbox server started successfully.")
+            print("Checking if both toolbox servers are successfully started...")
+            if toolbox_server_1.poll() is None and toolbox_server_2.poll() is None:
+                print("Toolbox servers started successfully.")
                 break
         else:
-            raise RuntimeError("Toolbox server failed to start after 5 retries.")
+            raise RuntimeError("Toolbox servers failed to start after 5 retries.")
     except subprocess.CalledProcessError as e:
         print(e.stderr.decode("utf-8"))
         print(e.stdout.decode("utf-8"))
@@ -164,5 +177,39 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     yield
 
     # Clean up toolbox server
-    toolbox_server.terminate()
-    toolbox_server.wait(timeout=5)
+    toolbox_server_1.terminate()
+    toolbox_server_2.terminate()
+    toolbox_server_1.wait(timeout=5)
+    toolbox_server_2.wait(timeout=5)
+
+
+@pytest.fixture(
+    params=[TOOLBOX_SERVER_URL_STABLE, TOOLBOX_SERVER_URL_DRAFT], scope="session"
+)
+def toolbox_server_url(request) -> str:
+    return request.param
+
+
+@pytest.fixture()
+def patch_toolbox_client_url(toolbox_server_url):
+    from toolbox_core.client import ToolboxClient
+    from toolbox_core.sync_client import ToolboxSyncClient
+
+    original_init = ToolboxClient.__init__
+    original_sync_init = ToolboxSyncClient.__init__
+
+    def new_init(self, url=TOOLBOX_SERVER_URL_STABLE, *args, **kwargs):
+        if url == TOOLBOX_SERVER_URL_STABLE:
+            url = toolbox_server_url
+        original_init(self, url, *args, **kwargs)
+
+    def new_sync_init(self, url=TOOLBOX_SERVER_URL_STABLE, *args, **kwargs):
+        if url == TOOLBOX_SERVER_URL_STABLE:
+            url = toolbox_server_url
+        original_sync_init(self, url, *args, **kwargs)
+
+    from unittest.mock import patch
+
+    with patch.object(ToolboxClient, "__init__", new_init, create=True):
+        with patch.object(ToolboxSyncClient, "__init__", new_sync_init, create=True):
+            yield

--- a/packages/toolbox-core/tests/conftest.py
+++ b/packages/toolbox-core/tests/conftest.py
@@ -29,6 +29,8 @@ import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
 
+from tests.constants import TOOLBOX_SERVER_URL_DRAFT, TOOLBOX_SERVER_URL_STABLE
+
 TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
 TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
 

--- a/packages/toolbox-core/tests/constants.py
+++ b/packages/toolbox-core/tests/constants.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"

--- a/packages/toolbox-core/tests/mcp_transport/test_v20241105.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20241105.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.mcp_transport.v20241105 import types
 from toolbox_core.mcp_transport.v20241105.mcp import McpHttpTransportV20241105
 from toolbox_core.protocol import ManifestSchema, Protocol
@@ -248,7 +249,7 @@ class TestMcpHttpTransportV20241105:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="MCP version mismatch"):
+        with pytest.raises(ProtocolNegotiationError):
             await transport._initialize_session()
 
     async def test_initialize_session_missing_tools_capability(self, transport, mocker):

--- a/packages/toolbox-core/tests/mcp_transport/test_v20241105.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20241105.py
@@ -159,6 +159,116 @@ class TestMcpHttpTransportV20241105:
         with pytest.raises(RuntimeError, match="MCP request failed"):
             await transport._send_request("url", TestRequest())
 
+    async def test_version_negotiation_raises_fallback(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server requests a fallback."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_raises_fallback_200_ok(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32022."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_empty_intersection(self, transport):
+        """Tests that the client errors immediately without retrying when there is no mutual version."""
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["UNSUPPORTED-VERSION"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(
+            RuntimeError, match="No mutually supported protocol version"
+        ):
+            await transport._send_request("url", TestRequest())
+
     async def test_send_notification(self, transport):
         mock_response = AsyncMock()
         mock_response.ok = True
@@ -432,3 +542,51 @@ class TestMcpHttpTransportV20241105:
 
         result = await transport.tool_invoke("tool", {}, {})
         assert result == '{"a": 1}'
+
+    async def test_send_request_400_with_json_rpc_error(self, transport):
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": {"code": -32602, "message": "Missing _meta"},
+        }
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(
+            RuntimeError, match="MCP request failed with code -32602: Missing _meta"
+        ):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_send_request_400_with_raw_text(self, transport):
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.side_effect = Exception("Not JSON")
+        mock_response.text.return_value = "<html>Bad Request</html>"
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="API request failed with status 400"):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_version_negotiation_legacy_string_fallback(self, transport):
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        request = types.MCPRequest(method="some/method", params={})
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": "invalid protocol version",
+        }
+
+        mock_post = transport._session.post.return_value
+        mock_post.__aenter__.return_value = mock_response_reject
+
+        with pytest.raises(RuntimeError, match="no fallback versions"):
+            await transport._send_request("http://test.local/messages", request)

--- a/packages/toolbox-core/tests/mcp_transport/test_v20250326.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20250326.py
@@ -177,6 +177,116 @@ class TestMcpHttpTransportV20250326:
         with pytest.raises(RuntimeError, match="MCP request failed"):
             await transport._send_request("url", TestRequest())
 
+    async def test_version_negotiation_raises_fallback(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server requests a fallback."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_raises_fallback_200_ok(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32022."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_empty_intersection(self, transport):
+        """Tests that the client errors immediately without retrying when there is no mutual version."""
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["UNSUPPORTED-VERSION"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(
+            RuntimeError, match="No mutually supported protocol version"
+        ):
+            await transport._send_request("url", TestRequest())
+
     async def test_send_notification(self, transport):
         mock_response = AsyncMock()
         mock_response.ok = True
@@ -430,3 +540,51 @@ class TestMcpHttpTransportV20250326:
 
         result = await transport.tool_invoke("tool", {}, {})
         assert result == '{"a": 1}'
+
+    async def test_send_request_400_with_json_rpc_error(self, transport):
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": {"code": -32602, "message": "Missing _meta"},
+        }
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(
+            RuntimeError, match="MCP request failed with code -32602: Missing _meta"
+        ):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_send_request_400_with_raw_text(self, transport):
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.side_effect = Exception("Not JSON")
+        mock_response.text.return_value = "<html>Bad Request</html>"
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="API request failed with status 400"):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_version_negotiation_legacy_string_fallback(self, transport):
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        request = types.MCPRequest(method="some/method", params={})
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": "invalid protocol version",
+        }
+
+        mock_post = transport._session.post.return_value
+        mock_post.__aenter__.return_value = mock_response_reject
+
+        with pytest.raises(ProtocolNegotiationError):
+            await transport._send_request("http://test.local/messages", request)

--- a/packages/toolbox-core/tests/mcp_transport/test_v20250618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20250618.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.mcp_transport.v20250618 import types
 from toolbox_core.mcp_transport.v20250618.mcp import McpHttpTransportV20250618
 from toolbox_core.protocol import ManifestSchema, Protocol, TelemetryAttributes
@@ -256,7 +257,7 @@ class TestMcpHttpTransportV20250618:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="MCP version mismatch"):
+        with pytest.raises(ProtocolNegotiationError):
             await transport._initialize_session()
 
     async def test_initialize_session_missing_tools_capability(self, transport, mocker):

--- a/packages/toolbox-core/tests/mcp_transport/test_v20250618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20250618.py
@@ -176,6 +176,116 @@ class TestMcpHttpTransportV20250618:
         with pytest.raises(RuntimeError, match="MCP request failed"):
             await transport._send_request("url", TestRequest())
 
+    async def test_version_negotiation_raises_fallback(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server requests a fallback."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_raises_fallback_200_ok(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32022."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_empty_intersection(self, transport):
+        """Tests that the client errors immediately without retrying when there is no mutual version."""
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["UNSUPPORTED-VERSION"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(
+            RuntimeError, match="No mutually supported protocol version"
+        ):
+            await transport._send_request("url", TestRequest())
+
     async def test_send_notification(self, transport):
         mock_response = AsyncMock()
         mock_response.ok = True
@@ -466,3 +576,51 @@ class TestMcpHttpTransportV20250618:
         assert "client.version" in telemetry_block
         assert telemetry_block["client.name"]  # non-empty
         assert telemetry_block["client.version"]  # non-empty
+
+    async def test_send_request_400_with_json_rpc_error(self, transport):
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": {"code": -32602, "message": "Missing _meta"},
+        }
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(
+            RuntimeError, match="MCP request failed with code -32602: Missing _meta"
+        ):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_send_request_400_with_raw_text(self, transport):
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.side_effect = Exception("Not JSON")
+        mock_response.text.return_value = "<html>Bad Request</html>"
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError, match="API request failed with status 400"):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_version_negotiation_legacy_string_fallback(self, transport):
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        request = types.MCPRequest(method="some/method", params={})
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": "invalid protocol version",
+        }
+
+        mock_post = transport._session.post.return_value
+        mock_post.__aenter__.return_value = mock_response_reject
+
+        with pytest.raises(ProtocolNegotiationError):
+            await transport._send_request("http://test.local/messages", request)

--- a/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.mcp_transport.v20251125 import types
 from toolbox_core.mcp_transport.v20251125.mcp import McpHttpTransportV20251125
 from toolbox_core.protocol import ManifestSchema, Protocol
@@ -256,7 +257,7 @@ class TestMcpHttpTransportV20251125:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="MCP version mismatch"):
+        with pytest.raises(ProtocolNegotiationError):
             await transport._initialize_session()
 
     async def test_initialize_session_missing_tools_capability(self, transport, mocker):

--- a/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
@@ -176,6 +176,116 @@ class TestMcpHttpTransportV20251125:
         with pytest.raises(RuntimeError, match="MCP request failed"):
             await transport._send_request("url", TestRequest())
 
+    async def test_version_negotiation_raises_fallback(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server requests a fallback."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_raises_fallback_200_ok(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32022."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_empty_intersection(self, transport):
+        """Tests that the client errors immediately without retrying when there is no mutual version."""
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["UNSUPPORTED-VERSION"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(
+            RuntimeError, match="No mutually supported protocol version"
+        ):
+            await transport._send_request("url", TestRequest())
+
     async def test_send_notification(self, transport):
         mock_response = AsyncMock()
         mock_response.ok = True
@@ -420,3 +530,54 @@ class TestMcpHttpTransportV20251125:
 
         result = await transport.tool_invoke("tool", {}, {})
         assert result == '{"a": 1}'
+
+    async def test_send_request_400_with_json_rpc_error(self, transport):
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": {"code": -32602, "message": "Missing _meta"},
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        with pytest.raises(
+            RuntimeError, match="MCP request failed with code -32602: Missing _meta"
+        ):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_send_request_400_with_raw_text(self, transport):
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.reason = "Bad Request"
+        mock_response.json.side_effect = Exception("Not JSON")
+        mock_response.text.return_value = "<html>Bad Request</html>"
+
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        request = types.MCPRequest(method="some/method", params={"key": "val"})
+        with pytest.raises(RuntimeError, match="API request failed with status 400"):
+            await transport._send_request("http://test.local/messages", request)
+
+    async def test_version_negotiation_legacy_string_fallback(self, transport):
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        request = types.MCPRequest(method="some/method", params={})
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "error": "invalid protocol version",
+        }
+
+        mock_post = transport._session.post.return_value
+        mock_post.__aenter__.return_value = mock_response_reject
+
+        with pytest.raises(ProtocolNegotiationError):
+            await transport._send_request("http://test.local/messages", request)

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
+from aioresponses import aioresponses
 
 from toolbox_core.mcp_transport.v20260618 import types
 from toolbox_core.mcp_transport.v20260618.mcp import McpHttpTransportV20260618
@@ -239,7 +240,7 @@ class TestMcpHttpTransportV20260618:
             "jsonrpc": "2.0",
             "id": "1",
             "error": {
-                "code": -32004,
+                "code": -32022,
                 "message": "Unsupported protocol version",
                 "data": {"supported": ["DRAFT-2026-v1"]},
             },
@@ -266,7 +267,7 @@ class TestMcpHttpTransportV20260618:
         assert transport._session.post.call_count == 1
 
     async def test_version_negotiation_raises_fallback_200_ok(self, transport):
-        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32004."""
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32022."""
         from toolbox_core.exceptions import ProtocolNegotiationError
 
         mock_response_reject = AsyncMock()
@@ -277,7 +278,7 @@ class TestMcpHttpTransportV20260618:
             "jsonrpc": "2.0",
             "id": "1",
             "error": {
-                "code": -32004,
+                "code": -32022,
                 "message": "Unsupported protocol version",
                 "data": {"supported": ["DRAFT-2026-v1"]},
             },
@@ -312,7 +313,7 @@ class TestMcpHttpTransportV20260618:
             "jsonrpc": "2.0",
             "id": "1",
             "error": {
-                "code": -32004,
+                "code": -32022,
                 "message": "Unsupported protocol version",
                 "data": {"supported": ["UNSUPPORTED-VERSION"]},
             },
@@ -365,3 +366,79 @@ class TestMcpHttpTransportV20260618:
         )
         result = await transport.tool_invoke("tool", {}, {})
         assert result == "Result"
+
+    async def test_send_request_400_with_json_rpc_error(self, transport):
+        # Test that an HTTP 400 with a non-negotiation JSON-RPC error is parsed properly.
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32602, "message": "missing _meta"},
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await transport._send_request(
+                "http://test.com/mcp",
+                types.JSONRPCRequest(method="test", params={}),
+            )
+
+        assert "MCP request failed with code -32602" in str(exc_info.value)
+        assert "missing _meta" in str(exc_info.value)
+
+    async def test_send_request_400_with_raw_text(self, transport):
+        # Test that an HTTP 400 with non-JSON text is raised with the raw string payload.
+        mock_response = AsyncMock()
+        mock_response.ok = False
+        mock_response.status = 400
+        mock_response.reason = "Bad Request"
+        mock_response.json.side_effect = Exception("Not JSON")
+        mock_response.text.return_value = "<html/>"
+
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await transport._send_request(
+                "http://test.com/mcp",
+                types.JSONRPCRequest(method="test", params={}),
+            )
+
+        assert "API request failed with status 400" in str(exc_info.value)
+        assert "<html/>" in str(exc_info.value)
+
+    async def test_version_negotiation_legacy_string_fallback(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns a string 'invalid protocol version' error."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": "invalid protocol version",
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        # The fallback defaults to picking the next version in the supported list, or 2025-11-25.
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == Protocol.MCP_v20251125
+        assert transport._session.post.call_count == 1

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+from aiohttp import ClientSession
+
+from toolbox_core.mcp_transport.v20260618 import types
+from toolbox_core.mcp_transport.v20260618.mcp import McpHttpTransportV20260618
+from toolbox_core.protocol import ManifestSchema, Protocol
+
+
+def create_fake_tools_list_result():
+    return types.ListToolsResult(
+        tools=[
+            {
+                "name": "get_weather",
+                "description": "Gets the weather.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            }
+        ]
+    )
+
+
+@pytest_asyncio.fixture(
+    params=[False, True], ids=["telemetry_disabled", "telemetry_enabled"]
+)
+async def transport(request, mocker):
+    if request.param:
+        mocker.patch("toolbox_core.mcp_transport.telemetry.TELEMETRY_AVAILABLE", True)
+        mocker.patch(
+            "toolbox_core.mcp_transport.telemetry.get_tracer", return_value=MagicMock()
+        )
+        mocker.patch(
+            "toolbox_core.mcp_transport.telemetry.get_meter", return_value=MagicMock()
+        )
+        mocker.patch(
+            "toolbox_core.mcp_transport.telemetry.create_operation_duration_histogram",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "toolbox_core.mcp_transport.telemetry.create_session_duration_histogram",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "toolbox_core.mcp_transport.telemetry.start_span",
+            return_value=(MagicMock(), "00-traceparent", ""),
+        )
+        mocker.patch("toolbox_core.mcp_transport.telemetry.end_span")
+        mocker.patch("toolbox_core.mcp_transport.telemetry.record_operation_duration")
+        mocker.patch("toolbox_core.mcp_transport.telemetry.record_session_duration")
+    mock_session = AsyncMock(spec=ClientSession)
+    transport = McpHttpTransportV20260618(
+        "http://fake-server.com",
+        session=mock_session,
+        protocol=Protocol.MCP_v20260618,
+        telemetry_enabled=request.param,
+    )
+    yield transport
+    await transport.close()
+
+
+@pytest.mark.asyncio
+class TestMcpHttpTransportV20260618:
+
+    # --- Request Sending Tests (Standard + Header) ---
+
+    async def test_send_request_success(self, transport):
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.status = 200
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        result = await transport._send_request("url", TestRequest())
+        assert result == TestResult()
+
+    async def test_send_request_adds_protocol_header(self, transport):
+        """Test that the MCP-Protocol-Version header is added."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request("url", TestRequest())
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["MCP-Protocol-Version"] == "DRAFT-2026-v1"
+
+    # --- Version Negotiation Tests ---
+
+    async def test_version_negotiation_raises_fallback(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server requests a fallback."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32004,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_empty_intersection(self, transport):
+        """Tests that the client errors immediately without retrying when there is no mutual version."""
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = False
+        mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32004,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["UNSUPPORTED-VERSION"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(
+            RuntimeError, match="No mutually supported protocol version"
+        ):
+            await transport._send_request("url", TestRequest())
+
+        assert transport._session.post.call_count == 1
+
+    # --- Tool Management Tests ---
+
+    async def test_tools_list_success(self, transport, mocker):
+        mocker.patch.object(transport, "_ensure_initialized", new_callable=AsyncMock)
+        mocker.patch.object(
+            transport,
+            "_send_request",
+            new_callable=AsyncMock,
+            return_value=create_fake_tools_list_result(),
+        )
+        manifest = await transport.tools_list()
+        assert isinstance(manifest, ManifestSchema)
+        assert "get_weather" in manifest.tools
+
+    async def test_tool_invoke_success(self, transport, mocker):
+        mocker.patch.object(transport, "_ensure_initialized", new_callable=AsyncMock)
+        mocker.patch.object(
+            transport,
+            "_send_request",
+            new_callable=AsyncMock,
+            return_value=types.CallToolResult(
+                content=[types.TextContent(type="text", text="Result")]
+            ),
+        )
+        result = await transport.tool_invoke("tool", {}, {})
+        assert result == "Result"

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -128,6 +128,39 @@ class TestMcpHttpTransportV20260618:
         call_args = transport._session.post.call_args
         headers = call_args.kwargs["headers"]
         assert headers["MCP-Protocol-Version"] == "DRAFT-2026-v1"
+        assert headers["Mcp-Method"] == "method"
+        assert "Mcp-Name" not in headers
+
+    async def test_send_request_adds_mcp_name_header(self, transport):
+        """Test that the Mcp-Name header is added for tools/call."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestParams(types.BaseModel):
+            name: str
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "tools/call"
+            params: TestParams
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request(
+            "url", TestRequest(params=TestParams(name="test_tool"))
+        )
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["Mcp-Method"] == "tools/call"
+        assert headers["Mcp-Name"] == "test_tool"
 
     # --- Version Negotiation Tests ---
 

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -70,7 +70,7 @@ async def transport(request, mocker):
     transport = McpHttpTransportV20260618(
         "http://fake-server.com",
         session=mock_session,
-        protocol=Protocol.MCP_v20260618,
+        protocol=Protocol.MCP_DRAFT,
         telemetry_enabled=request.param,
     )
     yield transport
@@ -131,7 +131,7 @@ class TestMcpHttpTransportV20260618:
         assert headers["Mcp-Method"] == "method"
         assert "Mcp-Name" not in headers
 
-    async def test_send_request_adds_mcp_name_header(self, transport):
+    async def test_send_request_adds_mcp_name_header_for_tools_call(self, transport):
         """Test that the Mcp-Name header is added for tools/call."""
         mock_response = AsyncMock()
         mock_response.ok = True
@@ -162,6 +162,70 @@ class TestMcpHttpTransportV20260618:
         assert headers["Mcp-Method"] == "tools/call"
         assert headers["Mcp-Name"] == "test_tool"
 
+    async def test_send_request_adds_mcp_name_header_for_prompts_get(self, transport):
+        """Test that the Mcp-Name header is added for prompts/get."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestParams(types.BaseModel):
+            name: str
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "prompts/get"
+            params: TestParams
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request(
+            "url", TestRequest(params=TestParams(name="test_prompt"))
+        )
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["Mcp-Method"] == "prompts/get"
+        assert headers["Mcp-Name"] == "test_prompt"
+
+    async def test_send_request_adds_mcp_name_header_for_resources_read(
+        self, transport
+    ):
+        """Test that the Mcp-Name header is added for resources/read."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestParams(types.BaseModel):
+            uri: str
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "resources/read"
+            params: TestParams
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request(
+            "url", TestRequest(params=TestParams(uri="file:///test.txt"))
+        )
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["Mcp-Method"] == "resources/read"
+        assert headers["Mcp-Name"] == "file:///test.txt"
+
     # --- Version Negotiation Tests ---
 
     async def test_version_negotiation_raises_fallback(self, transport):
@@ -171,6 +235,44 @@ class TestMcpHttpTransportV20260618:
         mock_response_reject = AsyncMock()
         mock_response_reject.ok = False
         mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32004,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_raises_fallback_200_ok(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32004."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
         mock_response_reject.json.return_value = {
             "jsonrpc": "2.0",
             "id": "1",

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -248,6 +248,94 @@ async def test_load_tool_not_found_in_manifest(mock_transport, test_tool_str):
     mock_transport.tool_get_mock.assert_awaited_once_with(REQUESTED_TOOL_NAME, {})
 
 
+@pytest.mark.asyncio
+async def test_load_tool_protocol_fallback_success(test_tool_str):
+    """
+    Tests that the client successfully swaps transports and retries when a
+    ProtocolNegotiationError is raised.
+    """
+    TOOL_NAME = "test_tool_1"
+    manifest = ManifestSchema(serverVersion="0.0.0", tools={TOOL_NAME: test_tool_str})
+
+    from toolbox_core.exceptions import ProtocolNegotiationError
+
+    # We need to mock the transports that client.py will instantiate
+    with (
+        patch("toolbox_core.client.McpHttpTransportV20260618") as mock_2026_cls,
+        patch("toolbox_core.client.McpHttpTransportV20250618") as mock_2025_cls,
+    ):
+
+        mock_2026 = AsyncMock()
+        mock_2026.base_url = TEST_BASE_URL
+        mock_2026.tool_get.side_effect = ProtocolNegotiationError("2025-06-18")
+        mock_2026_cls.return_value = mock_2026
+
+        mock_2025 = AsyncMock()
+        mock_2025.base_url = TEST_BASE_URL
+        mock_2025.tool_get.return_value = manifest
+        mock_2025.tool_invoke.return_value = "ok_from_fallback"
+        mock_2025_cls.return_value = mock_2025
+
+        async with ToolboxClient(
+            TEST_BASE_URL, protocol=Protocol.MCP_v20260618
+        ) as client:
+            # This should trigger the fallback
+            loaded_tool = await client.load_tool(TOOL_NAME)
+
+            # Assert the first transport was closed
+            mock_2026.close.assert_awaited_once()
+
+            # Assert the second transport was instantiated and used
+            mock_2025_cls.assert_called_once()
+            mock_2025.tool_get.assert_awaited_once_with(TOOL_NAME, {})
+
+            # Assert the tool was bound to the *new* transport
+            assert await loaded_tool("some value") == "ok_from_fallback"
+            mock_2025.tool_invoke.assert_awaited_once_with(
+                TOOL_NAME, {"param1": "some value"}, {}
+            )
+
+
+@pytest.mark.asyncio
+async def test_load_tool_protocol_fallback_infinite_loop_prevention(test_tool_str):
+    """
+    Tests that if the fallback transport *also* raises ProtocolNegotiationError,
+    the client does not get stuck in an infinite loop.
+    """
+    TOOL_NAME = "test_tool_1"
+
+    from toolbox_core.exceptions import ProtocolNegotiationError
+
+    with (
+        patch("toolbox_core.client.McpHttpTransportV20260618") as mock_2026_cls,
+        patch("toolbox_core.client.McpHttpTransportV20250618") as mock_2025_cls,
+    ):
+
+        mock_2026 = AsyncMock()
+        mock_2026.base_url = TEST_BASE_URL
+        mock_2026.tool_get.side_effect = ProtocolNegotiationError("2025-06-18")
+        mock_2026_cls.return_value = mock_2026
+
+        mock_2025 = AsyncMock()
+        mock_2025.base_url = TEST_BASE_URL
+        # The fallback transport also throws the error
+        mock_2025.tool_get.side_effect = ProtocolNegotiationError("2024-11-05")
+        mock_2025_cls.return_value = mock_2025
+
+        async with ToolboxClient(
+            TEST_BASE_URL, protocol=Protocol.MCP_v20260618
+        ) as client:
+            with pytest.raises(
+                ProtocolNegotiationError,
+                match="Server requires protocol fallback to 2024-11-05",
+            ):
+                await client.load_tool(TOOL_NAME)
+
+            # Assert we tried both, but then let the exception bubble up instead of looping
+            mock_2026.tool_get.assert_awaited_once()
+            mock_2025.tool_get.assert_awaited_once()
+
+
 class TestAuth:
     @pytest.fixture
     def expected_header(self):

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -21,7 +21,9 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from aiohttp import web
 
-from toolbox_core.client import ToolboxClient
+from tests.constants import TOOLBOX_SERVER_URL_STABLE
+from toolbox_core.client import ToolboxClient, _McpTransportProxy
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.itransport import ITransport
 from toolbox_core.protocol import (
     ManifestSchema,
@@ -814,7 +816,7 @@ def test_toolbox_client_no_warning_on_mcp():
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            client = ToolboxClient("http://localhost:5000", protocol=Protocol.MCP)
+            client = ToolboxClient(TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP)
             assert len(w) == 0
 
 
@@ -825,6 +827,137 @@ def test_toolbox_client_no_warning_on_explicit_mcp_version():
             warnings.simplefilter("always")
 
             client = ToolboxClient(
-                "http://localhost:5000", protocol=Protocol.MCP_v20251125
+                TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP_v20251125
             )
             assert len(w) == 0
+
+
+def test_toolbox_client_custom_protocols():
+    """Test that custom protocols array is correctly parsed and sorted."""
+    with patch("toolbox_core.client._McpTransportProxy") as mock_proxy:
+        client = ToolboxClient(
+            TOOLBOX_SERVER_URL_STABLE,
+            protocol=[Protocol.MCP_v20241105, Protocol.MCP_DRAFT, "2025-06-18"],
+        )
+        mock_proxy.assert_called_once()
+        args, kwargs = mock_proxy.call_args
+
+        # Check initial_protocol
+        assert args[2] == Protocol.MCP_DRAFT
+        # Check supported_protocols (must be sorted from newest to oldest)
+        assert args[6] == ["DRAFT-2026-v1", "2025-06-18", "2024-11-05"]
+
+
+def test_toolbox_client_custom_protocols_invalid():
+    """Test that custom protocols array raises error on invalid inputs."""
+
+    with pytest.raises(ValueError, match="protocol list cannot be empty"):
+        ToolboxClient(TOOLBOX_SERVER_URL_STABLE, protocol=[])
+
+    with pytest.raises(ValueError, match="Invalid protocol version 'invalid-version'"):
+        ToolboxClient(TOOLBOX_SERVER_URL_STABLE, protocol=["invalid-version"])
+
+
+@pytest.mark.asyncio
+async def test_artificial_array():
+    """The Artificial Array Test: simulate server returning 2025-03-26, should fallback to 2024-11-05."""
+    proxy = _McpTransportProxy(
+        "http://mock",
+        None,
+        Protocol.MCP_DRAFT,
+        None,
+        None,
+        False,
+        [Protocol.MCP_DRAFT.value, Protocol.MCP_v20241105.value],
+    )
+
+    proxy._active_transport.tool_get = AsyncMock(
+        side_effect=ProtocolNegotiationError(Protocol.MCP_v20250326.value)
+    )
+
+    with patch.object(proxy, "_create_transport") as mock_create:
+        mock_new_transport = AsyncMock()
+        mock_new_transport.tool_get.return_value = "success"
+        mock_create.return_value = mock_new_transport
+
+        res = await proxy.tool_get("mock")
+
+        assert res == "success"
+        mock_create.assert_called_with(Protocol.MCP_v20241105)
+
+
+@pytest.mark.asyncio
+async def test_cascading_fallback():
+    """The Cascading Fallback Test: simulate server stateless generic error which throws the next stateful version."""
+    proxy = _McpTransportProxy(
+        "http://mock",
+        None,
+        Protocol.MCP_DRAFT,
+        None,
+        None,
+        False,
+        [Protocol.MCP_DRAFT.value, Protocol.MCP_v20251125.value],
+    )
+
+    proxy._active_transport.tool_get = AsyncMock(
+        side_effect=ProtocolNegotiationError(Protocol.MCP_v20251125.value)
+    )
+
+    with patch.object(proxy, "_create_transport") as mock_create:
+        mock_new_transport = AsyncMock()
+        mock_new_transport.tool_get.return_value = "success"
+        mock_create.return_value = mock_new_transport
+
+        res = await proxy.tool_get("mock")
+
+        assert res == "success"
+        mock_create.assert_called_with(Protocol.MCP_v20251125)
+
+
+@pytest.mark.asyncio
+async def test_strict_constraint():
+    """The Strict Constraint Test: simulate legacy server returning an unsupported old version."""
+    proxy = _McpTransportProxy(
+        "http://mock",
+        None,
+        Protocol.MCP_DRAFT,
+        None,
+        None,
+        False,
+        [Protocol.MCP_DRAFT.value, Protocol.MCP_v20251125.value],
+    )
+
+    proxy._active_transport.tool_get = AsyncMock(
+        side_effect=ProtocolNegotiationError(Protocol.MCP_v20241105.value)
+    )
+
+    with pytest.raises(RuntimeError, match="No mutually supported protocol version"):
+        await proxy.tool_get("mock")
+
+
+@pytest.mark.asyncio
+async def test_modern_smart_fallback():
+    """The Modern Smart-Fallback Test: simulate modern payload correctly returning pre-intersected fallback."""
+    proxy = _McpTransportProxy(
+        "http://mock",
+        None,
+        Protocol.MCP_DRAFT,
+        None,
+        None,
+        False,
+        [Protocol.MCP_DRAFT.value, Protocol.MCP_v20241105.value],
+    )
+
+    proxy._active_transport.tool_get = AsyncMock(
+        side_effect=ProtocolNegotiationError(Protocol.MCP_v20241105.value)
+    )
+
+    with patch.object(proxy, "_create_transport") as mock_create:
+        mock_new_transport = AsyncMock()
+        mock_new_transport.tool_get.return_value = "success"
+        mock_create.return_value = mock_new_transport
+
+        res = await proxy.tool_get("mock")
+
+        assert res == "success"
+        mock_create.assert_called_with(Protocol.MCP_v20241105)

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -276,9 +276,7 @@ async def test_load_tool_protocol_fallback_success(test_tool_str):
         mock_2025.tool_invoke.return_value = "ok_from_fallback"
         mock_2025_cls.return_value = mock_2025
 
-        async with ToolboxClient(
-            TEST_BASE_URL, protocol=Protocol.MCP_v20260618
-        ) as client:
+        async with ToolboxClient(TEST_BASE_URL, protocol=Protocol.MCP_DRAFT) as client:
             # This should trigger the fallback
             loaded_tool = await client.load_tool(TOOL_NAME)
 
@@ -322,9 +320,7 @@ async def test_load_tool_protocol_fallback_infinite_loop_prevention(test_tool_st
         mock_2025.tool_get.side_effect = ProtocolNegotiationError("2024-11-05")
         mock_2025_cls.return_value = mock_2025
 
-        async with ToolboxClient(
-            TEST_BASE_URL, protocol=Protocol.MCP_v20260618
-        ) as client:
+        async with ToolboxClient(TEST_BASE_URL, protocol=Protocol.MCP_DRAFT) as client:
             with pytest.raises(
                 ProtocolNegotiationError,
                 match="Server requires protocol fallback to 2024-11-05",
@@ -814,7 +810,7 @@ async def test_client_init_with_client_info():
 def test_toolbox_client_no_warning_on_mcp():
     """Test that initializing ToolboxClient with Protocol.MCP issues NO DeprecationWarning."""
     # Mock the transport to avoid actual connection attempts or MCP version warnings
-    with patch("toolbox_core.client.McpHttpTransportV20250618") as mock_transport:
+    with patch("toolbox_core.client.McpHttpTransportV20251125") as mock_transport:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -19,6 +19,7 @@ import pytest
 import pytest_asyncio
 from pydantic import ValidationError
 
+from tests.constants import TOOLBOX_SERVER_URL_STABLE
 from toolbox_core.client import ToolboxClient
 from toolbox_core.protocol import Protocol
 from toolbox_core.tool import ToolboxTool
@@ -30,7 +31,10 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 @pytest_asyncio.fixture(scope="function")
 async def toolbox():
     """Creates a ToolboxClient instance shared by all tests in this module."""
-    toolbox = ToolboxClient("http://localhost:5000", protocol=Protocol.MCP)
+    # Note: The STABLE URL passed here is automatically patched by the
+    # 'patch_toolbox_client_url' fixture to run against both
+    # the STABLE (5000) and DRAFT (5001) servers.
+    toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP)
     try:
         yield toolbox
     finally:
@@ -114,7 +118,7 @@ class TestBasicE2E:
     async def test_load_and_run_tool_with_telemetry(self, telemetry_enabled: bool):
         """Load and invoke a tool with telemetry_enabled=True/False."""
         async with ToolboxClient(
-            "http://localhost:5000",
+            TOOLBOX_SERVER_URL_STABLE,
             protocol=Protocol.MCP,
             telemetry_enabled=telemetry_enabled,
         ) as toolbox:

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -23,6 +23,8 @@ from toolbox_core.client import ToolboxClient
 from toolbox_core.protocol import Protocol
 from toolbox_core.tool import ToolboxTool
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 # --- Shared Fixtures Defined at Module Level ---
 @pytest_asyncio.fixture(scope="function")

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -24,9 +24,11 @@ from toolbox_core.protocol import Protocol
 from toolbox_core.tool import ToolboxTool
 
 
+# TODO: Include draft versions in E2E integration tests once the server
+# supports SEP-2575 (stateless MCP / Request-Metadata).
 @pytest_asyncio.fixture(
     scope="function",
-    params=Protocol.get_supported_mcp_versions(),
+    params=[v for v in Protocol.get_supported_mcp_versions() if "DRAFT" not in v],
 )
 async def toolbox(request):
     """Creates a ToolboxClient instance shared by all tests in this module."""
@@ -97,6 +99,21 @@ class TestBasicE2E:
         """Invoke a tool with missing params."""
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):
             await get_n_rows_tool()
+
+    async def test_protocol_fallback_e2e(self):
+        """Tests that a client using MCP_LATEST can fallback to an older protocol against a server that doesn't support the latest version."""
+        # The E2E server currently does not support DRAFT 2026, so this will trigger a fallback.
+        async with ToolboxClient(
+            "http://localhost:5000", protocol=Protocol.MCP_LATEST
+        ) as client:
+            tool = await client.load_tool("get-n-rows")
+            response = await tool(num_rows="1")
+            assert "row1" in response
+            # Verify that fallback occurred by checking the transport's final protocol version
+            assert (
+                client._ToolboxClient__transport._protocol_version
+                != Protocol.MCP_LATEST.value
+            )
 
     async def test_run_tool_wrong_param_type(self, get_n_rows_tool: ToolboxTool):
         """Invoke a tool with wrong param type."""

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -26,11 +26,9 @@ from toolbox_core.tool import ToolboxTool
 pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
 
-# TODO: Include draft versions in E2E integration tests once the server
-# supports SEP-2575 (stateless MCP / Request-Metadata).
 @pytest_asyncio.fixture(
     scope="function",
-    params=[v for v in Protocol.get_supported_mcp_versions() if "DRAFT" not in v],
+    params=[v for v in Protocol.get_supported_mcp_versions()],
 )
 async def toolbox(request):
     """Creates a ToolboxClient instance shared by all tests in this module."""
@@ -102,25 +100,26 @@ class TestBasicE2E:
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):
             await get_n_rows_tool()
 
-    async def test_protocol_fallback_e2e(self, toolbox_server_url):
-        """Tests that a client using MCP_LATEST can fallback to an older protocol against a server that doesn't support the latest version."""
-        # The E2E server currently does not support DRAFT 2026, so this will trigger a fallback.
+    async def test_protocol_fallback_e2e(self, toolbox_server_url: str):
+        """Tests that a client using MCP_DRAFT can fallback to an older protocol against a server that doesn't support the draft version."""
+        # The E2E server currently does not support DRAFT 2026 on port 5000, so this will trigger a fallback.
+        # However, port 5001 does support DRAFT 2026.
         async with ToolboxClient(
-            toolbox_server_url, protocol=Protocol.MCP_LATEST
+            toolbox_server_url, protocol=Protocol.MCP_DRAFT
         ) as client:
             tool = await client.load_tool("get-n-rows")
             response = await tool(num_rows="1")
             assert "row1" in response
             # Verify that fallback occurred by checking the transport's final protocol version
-            if "5000" in toolbox_server_url:
+            if "5001" in toolbox_server_url:
                 assert (
                     client._ToolboxClient__transport._protocol_version
-                    != Protocol.MCP_LATEST.value
+                    == Protocol.MCP_DRAFT.value
                 )
             else:
                 assert (
                     client._ToolboxClient__transport._protocol_version
-                    == Protocol.MCP_LATEST.value
+                    != Protocol.MCP_DRAFT.value
                 )
 
     async def test_run_tool_wrong_param_type(self, get_n_rows_tool: ToolboxTool):
@@ -471,3 +470,25 @@ class TestMapParams:
                 execution_context={"env": "staging"},
                 user_scores={"user4": "not-an-integer"},
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("toolbox_server")
+async def test_mcp_default_protocol():
+    """Verify that omitting the protocol argument defaults correctly and works."""
+    async with ToolboxClient("http://localhost:5000") as client:
+        tool = await client.load_tool("get-n-rows")
+        response = await tool(num_rows="1")
+        assert "row1" in response
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("toolbox_server")
+async def test_mcp_draft_fallback():
+    """Verify that explicitly using MCP_DRAFT against a server that doesn't support it falls back successfully."""
+    async with ToolboxClient(
+        "http://localhost:5000", protocol=Protocol.MCP_DRAFT
+    ) as client:
+        tool = await client.load_tool("get-n-rows")
+        response = await tool(num_rows="1")
+        assert "row1" in response

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -23,6 +23,8 @@ from toolbox_core.client import ToolboxClient
 from toolbox_core.protocol import Protocol
 from toolbox_core.tool import ToolboxTool
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 # TODO: Include draft versions in E2E integration tests once the server
 # supports SEP-2575 (stateless MCP / Request-Metadata).
@@ -100,20 +102,26 @@ class TestBasicE2E:
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):
             await get_n_rows_tool()
 
-    async def test_protocol_fallback_e2e(self):
+    async def test_protocol_fallback_e2e(self, toolbox_server_url):
         """Tests that a client using MCP_LATEST can fallback to an older protocol against a server that doesn't support the latest version."""
         # The E2E server currently does not support DRAFT 2026, so this will trigger a fallback.
         async with ToolboxClient(
-            "http://localhost:5000", protocol=Protocol.MCP_LATEST
+            toolbox_server_url, protocol=Protocol.MCP_LATEST
         ) as client:
             tool = await client.load_tool("get-n-rows")
             response = await tool(num_rows="1")
             assert "row1" in response
             # Verify that fallback occurred by checking the transport's final protocol version
-            assert (
-                client._ToolboxClient__transport._protocol_version
-                != Protocol.MCP_LATEST.value
-            )
+            if "5000" in toolbox_server_url:
+                assert (
+                    client._ToolboxClient__transport._protocol_version
+                    != Protocol.MCP_LATEST.value
+                )
+            else:
+                assert (
+                    client._ToolboxClient__transport._protocol_version
+                    == Protocol.MCP_LATEST.value
+                )
 
     async def test_run_tool_wrong_param_type(self, get_n_rows_tool: ToolboxTool):
         """Invoke a tool with wrong param type."""

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -19,6 +19,7 @@ import pytest
 import pytest_asyncio
 from pydantic import ValidationError
 
+from tests.constants import TOOLBOX_SERVER_URL_DRAFT, TOOLBOX_SERVER_URL_STABLE
 from toolbox_core.client import ToolboxClient
 from toolbox_core.protocol import Protocol
 from toolbox_core.tool import ToolboxTool
@@ -32,7 +33,10 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 )
 async def toolbox(request):
     """Creates a ToolboxClient instance shared by all tests in this module."""
-    toolbox = ToolboxClient("http://localhost:5000", protocol=Protocol(request.param))
+    # Note: The STABLE URL passed here is automatically patched by the
+    # 'patch_toolbox_client_url' fixture to run against both
+    # the STABLE (5000) and DRAFT (5001) servers.
+    toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE, protocol=Protocol(request.param))
     try:
         yield toolbox
     finally:
@@ -102,8 +106,8 @@ class TestBasicE2E:
 
     async def test_protocol_fallback_e2e(self, toolbox_server_url: str):
         """Tests that a client using MCP_DRAFT can fallback to an older protocol against a server that doesn't support the draft version."""
-        # The E2E server currently does not support DRAFT 2026 on port 5000, so this will trigger a fallback.
-        # However, port 5001 does support DRAFT 2026.
+        # The stable server currently does not support DRAFT 2026, so this will trigger a fallback.
+        # However, the draft server does support DRAFT 2026.
         async with ToolboxClient(
             toolbox_server_url, protocol=Protocol.MCP_DRAFT
         ) as client:
@@ -111,7 +115,7 @@ class TestBasicE2E:
             response = await tool(num_rows="1")
             assert "row1" in response
             # Verify that fallback occurred by checking the transport's final protocol version
-            if "5001" in toolbox_server_url:
+            if toolbox_server_url == TOOLBOX_SERVER_URL_DRAFT:
                 assert (
                     client._ToolboxClient__transport._protocol_version
                     == Protocol.MCP_DRAFT.value
@@ -190,11 +194,14 @@ class TestAuth:
         requires a different authentication than the one provided."""
         tool = await toolbox.load_tool("get-row-by-id-auth")
         auth_tool = tool.add_auth_token_getters({"my-test-auth": lambda: auth_token2})
-        with pytest.raises(
-            Exception,
-            match=r"401 \(Unauthorized\)",
-        ):
+        try:
             await auth_tool(id="2")
+            pytest.fail("Expected tool to fail with auth error")
+        except Exception as e:
+            err_str = str(e)
+            assert (
+                "401" in err_str or "-32600" in err_str
+            ), f"Unexpected error message: {err_str}"
 
     async def test_run_tool_auth(self, toolbox: ToolboxClient, auth_token1: str):
         """Tests running a tool with correct auth."""
@@ -474,9 +481,9 @@ class TestMapParams:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")
-async def test_mcp_default_protocol():
+async def test_mcp_default_protocol(toolbox_server_url: str):
     """Verify that omitting the protocol argument defaults correctly and works."""
-    async with ToolboxClient("http://localhost:5000") as client:
+    async with ToolboxClient(toolbox_server_url) as client:
         tool = await client.load_tool("get-n-rows")
         response = await tool(num_rows="1")
         assert "row1" in response
@@ -484,11 +491,53 @@ async def test_mcp_default_protocol():
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")
-async def test_mcp_draft_fallback():
+async def test_mcp_draft_fallback(toolbox_server_url: str):
     """Verify that explicitly using MCP_DRAFT against a server that doesn't support it falls back successfully."""
+    async with ToolboxClient(toolbox_server_url, protocol=Protocol.MCP_DRAFT) as client:
+        tool = await client.load_tool("get-n-rows")
+        response = await tool(num_rows="1")
+        assert "row1" in response
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("toolbox_server")
+async def test_mcp_latest_protocol(toolbox_server_url: str):
+    """Verify that explicitly using MCP_LATEST works successfully."""
     async with ToolboxClient(
-        "http://localhost:5000", protocol=Protocol.MCP_DRAFT
+        toolbox_server_url, protocol=Protocol.MCP_LATEST
     ) as client:
         tool = await client.load_tool("get-n-rows")
         response = await tool(num_rows="1")
         assert "row1" in response
+        assert (
+            client._ToolboxClient__transport._protocol_version
+            == Protocol.MCP_LATEST.value
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("toolbox_server")
+async def test_mcp_custom_protocols_list(toolbox_server_url: str):
+    """Verify that passing a list of protocols with MCP_LATEST and MCP_DRAFT works successfully."""
+    async with ToolboxClient(
+        toolbox_server_url,
+        protocol=[
+            Protocol.MCP_v20241105,
+            Protocol.MCP_v20250326,
+            Protocol.MCP_LATEST,
+            Protocol.MCP_DRAFT,
+        ],
+    ) as client:
+        tool = await client.load_tool("get-n-rows")
+        response = await tool(num_rows="1")
+        assert "row1" in response
+        if toolbox_server_url == TOOLBOX_SERVER_URL_STABLE:
+            assert (
+                client._ToolboxClient__transport._protocol_version
+                == Protocol.MCP_LATEST.value
+            )
+        else:
+            assert (
+                client._ToolboxClient__transport._protocol_version
+                == Protocol.MCP_DRAFT.value
+            )

--- a/packages/toolbox-core/tests/test_protocol.py
+++ b/packages/toolbox-core/tests/test_protocol.py
@@ -77,7 +77,13 @@ def test_get_supported_mcp_versions():
     Tests that get_supported_mcp_versions returns the correct list of versions,
     sorted from newest to oldest.
     """
-    expected_versions = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
+    expected_versions = [
+        "DRAFT-2026-v1",
+        "2025-11-25",
+        "2025-06-18",
+        "2025-03-26",
+        "2024-11-05",
+    ]
     supported_versions = Protocol.get_supported_mcp_versions()
 
     assert supported_versions == expected_versions

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from tests.constants import TOOLBOX_SERVER_URL_STABLE
 from toolbox_core.sync_client import ToolboxSyncClient
 from toolbox_core.sync_tool import ToolboxSyncTool
 
@@ -24,7 +25,10 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 @pytest.fixture(scope="module")
 def toolbox():
     """Creates a ToolboxSyncClient instance shared by all tests in this module."""
-    toolbox = ToolboxSyncClient("http://localhost:5000")
+    # Note: The STABLE URL passed here is automatically patched by the
+    # 'patch_toolbox_client_url' fixture to run against both
+    # the STABLE (5000) and DRAFT (5001) servers.
+    toolbox = ToolboxSyncClient(TOOLBOX_SERVER_URL_STABLE)
     try:
         yield toolbox
     finally:

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -17,6 +17,8 @@ import pytest
 from toolbox_core.sync_client import ToolboxSyncClient
 from toolbox_core.sync_tool import ToolboxSyncTool
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 # --- Shared Fixtures Defined at Module Level ---
 @pytest.fixture(scope="module")

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -410,9 +410,7 @@ def test_tool_init_basic(http_session, sample_tool_params, sample_tool_descripti
             client_headers={},
         )
     relevant_warnings = [
-        w
-        for w in record
-        if not issubclass(w.category, (ResourceWarning, DeprecationWarning))
+        w for w in record if not issubclass(w.category, ResourceWarning)
     ]
     assert (
         len(relevant_warnings) == 0

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -409,9 +409,14 @@ def test_tool_init_basic(http_session, sample_tool_params, sample_tool_descripti
             bound_params={},
             client_headers={},
         )
+    relevant_warnings = [
+        w
+        for w in record
+        if not issubclass(w.category, (ResourceWarning, DeprecationWarning))
+    ]
     assert (
-        len(record) == 0
-    ), f"ToolboxTool instantiation unexpectedly warned: {[f'{w.category.__name__}: {w.message}' for w in record]}"
+        len(relevant_warnings) == 0
+    ), f"ToolboxTool instantiation unexpectedly warned: {[f'{w.category.__name__}: {w.message}' for w in relevant_warnings]}"
 
     assert tool_instance.__name__ == TEST_TOOL_NAME
     assert inspect.iscoroutinefunction(tool_instance.__call__)

--- a/packages/toolbox-langchain/integration.cloudbuild.yaml
+++ b/packages/toolbox-langchain/integration.cloudbuild.yaml
@@ -49,5 +49,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: '1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-langchain/pyproject.toml
+++ b/packages/toolbox-langchain/pyproject.toml
@@ -53,6 +53,7 @@ test = [
     "Pillow==12.2.0; python_version >= '3.10'",
     "google-cloud-secret-manager==2.28.0",
     "google-cloud-storage==3.10.1",
+    "numpy<2", # Pinned to <2 to prevent mypy syntax errors on python 3.10 with numpy 2.x stubs
 ]
 
 [build-system]

--- a/packages/toolbox-langchain/src/toolbox_langchain/async_client.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Awaitable, Callable, Mapping, Optional, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 from warnings import warn
 
 from aiohttp import ClientSession
@@ -35,7 +35,7 @@ class AsyncToolboxClient:
         client_headers: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
         ] = None,
-        protocol: Protocol = Protocol.MCP,
+        protocol: Union[Protocol, list[Protocol], list[str]] = Protocol.MCP,
         telemetry_enabled: bool = False,
     ):
         """

--- a/packages/toolbox-langchain/src/toolbox_langchain/client.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from asyncio import to_thread
-from typing import Any, Awaitable, Callable, Mapping, Optional, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 from warnings import warn
 
 from toolbox_core.protocol import Protocol
@@ -31,7 +31,7 @@ class ToolboxClient:
         client_headers: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
         ] = None,
-        protocol: Protocol = Protocol.MCP,
+        protocol: Union[Protocol, list[Protocol], list[str]] = Protocol.MCP,
         telemetry_enabled: bool = False,
     ) -> None:
         """

--- a/packages/toolbox-langchain/tests/conftest.py
+++ b/packages/toolbox-langchain/tests/conftest.py
@@ -25,9 +25,12 @@ import time
 from typing import Generator
 
 import google
-import pytest_asyncio
+import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
 
 
 #### Define Utility Functions
@@ -92,17 +95,17 @@ def get_auth_token(client_id: str) -> str:
 
 
 #### Define Fixtures
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def project_id() -> str:
     return get_env_var("GOOGLE_CLOUD_PROJECT")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_version() -> str:
     return get_env_var("TOOLBOX_VERSION")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def tools_file_path(project_id: str) -> Generator[str]:
     """Provides a temporary file path containing the tools manifest."""
     tools_manifest = access_secret_version(
@@ -115,7 +118,7 @@ def tools_file_path(project_id: str) -> Generator[str]:
     os.remove(tools_file_path)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token1(project_id: str) -> str:
     client_id = access_secret_version(
         project_id=project_id, secret_id="sdk_testing_client1"
@@ -123,7 +126,7 @@ def auth_token1(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token2(project_id: str) -> str:
     client_id = access_secret_version(
         project_id=project_id, secret_id="sdk_testing_client2"
@@ -131,7 +134,7 @@ def auth_token2(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None]:
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
@@ -143,20 +146,30 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
         # Make toolbox executable
         os.chmod("toolbox", 0o700)
         # Run toolbox binary
-        toolbox_server = subprocess.Popen(
-            ["./toolbox", "--tools-file", tools_file_path]
+        toolbox_server_1 = subprocess.Popen(
+            ["./toolbox", "--port", "5000", "--tools-file", tools_file_path]
+        )
+        toolbox_server_2 = subprocess.Popen(
+            [
+                "./toolbox",
+                "--port",
+                "5001",
+                "--tools-file",
+                tools_file_path,
+                "--enable-draft-specs",
+            ]
         )
 
         # Wait for server to start
         # Retry logic with a timeout
         for _ in range(5):  # retries
-            time.sleep(2)
-            print("Checking if toolbox is successfully started...")
-            if toolbox_server.poll() is None:
-                print("Toolbox server started successfully.")
+            time.sleep(4)
+            print("Checking if both toolbox servers are successfully started...")
+            if toolbox_server_1.poll() is None and toolbox_server_2.poll() is None:
+                print("Toolbox servers started successfully.")
                 break
         else:
-            raise RuntimeError("Toolbox server failed to start after 5 retries.")
+            raise RuntimeError("Toolbox servers failed to start after 5 retries.")
     except subprocess.CalledProcessError as e:
         print(e.stderr.decode("utf-8"))
         print(e.stdout.decode("utf-8"))
@@ -164,5 +177,31 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     yield
 
     # Clean up toolbox server
-    toolbox_server.terminate()
-    toolbox_server.wait()
+    toolbox_server_1.terminate()
+    toolbox_server_2.terminate()
+    toolbox_server_1.wait()
+    toolbox_server_2.wait()
+
+
+@pytest.fixture(
+    params=[TOOLBOX_SERVER_URL_STABLE, TOOLBOX_SERVER_URL_DRAFT], scope="session"
+)
+def toolbox_server_url(request) -> str:
+    return request.param
+
+
+@pytest.fixture()
+def patch_toolbox_client_url(toolbox_server_url):
+    from toolbox_core.client import ToolboxClient
+
+    original_init = ToolboxClient.__init__
+
+    def new_init(self, url=TOOLBOX_SERVER_URL_STABLE, *args, **kwargs):
+        if url == TOOLBOX_SERVER_URL_STABLE:
+            url = toolbox_server_url
+        original_init(self, url, *args, **kwargs)
+
+    from unittest.mock import patch
+
+    with patch.object(ToolboxClient, "__init__", new_init, create=True):
+        yield

--- a/packages/toolbox-langchain/tests/conftest.py
+++ b/packages/toolbox-langchain/tests/conftest.py
@@ -29,8 +29,7 @@ import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
 
-TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
-TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
+from tests.constants import TOOLBOX_SERVER_URL_DRAFT, TOOLBOX_SERVER_URL_STABLE
 
 
 #### Define Utility Functions

--- a/packages/toolbox-langchain/tests/constants.py
+++ b/packages/toolbox-langchain/tests/constants.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -44,6 +44,8 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
 TOOLBOX_SERVER_URL = "http://localhost:5000"
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -37,12 +37,10 @@ This file covers the following use cases:
 import pytest
 import pytest_asyncio
 from pydantic import ValidationError
+from toolbox_core.protocol import Protocol
 
+from tests.constants import TOOLBOX_SERVER_URL_STABLE
 from toolbox_langchain.client import ToolboxClient
-
-pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
-
-TOOLBOX_SERVER_URL = "http://localhost:5000"
 
 pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
@@ -53,7 +51,10 @@ class TestE2EClientAsync:
     @pytest.fixture(scope="function")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
+        # Note: The STABLE URL passed here is automatically patched by the
+        # 'patch_toolbox_client_url' fixture to run against both
+        # the STABLE (5000) and DRAFT (5001) servers.
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
         return toolbox
 
     @pytest_asyncio.fixture(scope="function")
@@ -94,6 +95,14 @@ class TestE2EClientAsync:
         for tool in toolset:
             name = tool._ToolboxTool__core_tool.__name__
             assert name in tool_names
+
+    async def test_aload_toolset_explicit_protocol(self):
+        toolbox = ToolboxClient(
+            TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP_v20251125
+        )
+        toolset = await toolbox.aload_toolset()
+        assert len(toolset) == 7
+        toolbox.close()
 
     async def test_run_tool_async(self, get_n_rows_tool):
         response = await get_n_rows_tool.ainvoke({"num_rows": "2"})
@@ -147,11 +156,14 @@ class TestE2EClientAsync:
             "get-row-by-id-auth",
         )
         auth_tool = tool.add_auth_token_getter("my-test-auth", lambda: auth_token2)
-        with pytest.raises(
-            Exception,
-            match=r"401 \(Unauthorized\)",
-        ):
+        try:
             await auth_tool.ainvoke({"id": "2"})
+            pytest.fail("Expected tool to fail with auth error")
+        except Exception as e:
+            err_str = str(e)
+            assert (
+                "401" in err_str or "-32600" in err_str
+            ), f"Unexpected error message: {err_str}"
 
     async def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -200,7 +212,10 @@ class TestE2EClientSync:
     @pytest.fixture(scope="session")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
+        # Note: The STABLE URL passed here is automatically patched by the
+        # 'patch_toolbox_client_url' fixture to run against both
+        # the STABLE (5000) and DRAFT (5001) servers.
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
         return toolbox
 
     @pytest.fixture(scope="function")
@@ -241,6 +256,14 @@ class TestE2EClientSync:
         for tool in toolset:
             name = tool._ToolboxTool__core_tool.__name__
             assert name in tool_names
+
+    def test_load_toolset_explicit_protocol(self):
+        toolbox = ToolboxClient(
+            TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP_v20251125
+        )
+        toolset = toolbox.load_toolset()
+        assert len(toolset) == 7
+        toolbox.close()
 
     @pytest.mark.asyncio
     async def test_run_tool_async(self, get_n_rows_tool):
@@ -294,11 +317,14 @@ class TestE2EClientSync:
             "get-row-by-id-auth",
         )
         auth_tool = tool.add_auth_token_getter("my-test-auth", lambda: auth_token2)
-        with pytest.raises(
-            Exception,
-            match=r"401 \(Unauthorized\)",
-        ):
+        try:
             auth_tool.invoke({"id": "2"})
+            pytest.fail("Expected tool to fail with auth error")
+        except Exception as e:
+            err_str = str(e)
+            assert (
+                "401" in err_str or "-32600" in err_str
+            ), f"Unexpected error message: {err_str}"
 
     def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -40,6 +40,10 @@ from pydantic import ValidationError
 
 from toolbox_langchain.client import ToolboxClient
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
+TOOLBOX_SERVER_URL = "http://localhost:5000"
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")
@@ -47,7 +51,7 @@ class TestE2EClientAsync:
     @pytest.fixture(scope="function")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient("http://localhost:5000")
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
         return toolbox
 
     @pytest_asyncio.fixture(scope="function")
@@ -194,7 +198,7 @@ class TestE2EClientSync:
     @pytest.fixture(scope="session")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient("http://localhost:5000")
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
         return toolbox
 
     @pytest.fixture(scope="function")

--- a/packages/toolbox-llamaindex/integration.cloudbuild.yaml
+++ b/packages/toolbox-llamaindex/integration.cloudbuild.yaml
@@ -49,5 +49,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '1.5.0'
+  _TOOLBOX_VERSION: '1.6.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-llamaindex/pyproject.toml
+++ b/packages/toolbox-llamaindex/pyproject.toml
@@ -53,6 +53,7 @@ test = [
     "Pillow==12.2.0; python_version >= '3.10'",
     "google-cloud-secret-manager==2.28.0",
     "google-cloud-storage==3.10.1",
+    "numpy<2", # Pinned to <2 to prevent mypy syntax errors on python 3.10 with numpy 2.x stubs
 ]
 
 [build-system]

--- a/packages/toolbox-llamaindex/src/toolbox_llamaindex/async_client.py
+++ b/packages/toolbox-llamaindex/src/toolbox_llamaindex/async_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Awaitable, Callable, Mapping, Optional, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 from warnings import warn
 
 from aiohttp import ClientSession
@@ -35,7 +35,7 @@ class AsyncToolboxClient:
         client_headers: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
         ] = None,
-        protocol: Protocol = Protocol.MCP,
+        protocol: Union[Protocol, list[Protocol], list[str]] = Protocol.MCP,
         telemetry_enabled: bool = False,
     ):
         """

--- a/packages/toolbox-llamaindex/src/toolbox_llamaindex/client.py
+++ b/packages/toolbox-llamaindex/src/toolbox_llamaindex/client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from asyncio import to_thread
-from typing import Any, Awaitable, Callable, Mapping, Optional, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 from warnings import warn
 
 from toolbox_core.protocol import Protocol
@@ -32,7 +32,7 @@ class ToolboxClient:
         client_headers: Optional[
             Mapping[str, Union[Callable[[], str], Callable[[], Awaitable[str]], str]]
         ] = None,
-        protocol: Protocol = Protocol.MCP,
+        protocol: Union[Protocol, list[Protocol], list[str]] = Protocol.MCP,
         telemetry_enabled: bool = False,
     ) -> None:
         """

--- a/packages/toolbox-llamaindex/tests/conftest.py
+++ b/packages/toolbox-llamaindex/tests/conftest.py
@@ -25,9 +25,12 @@ import time
 from typing import Generator
 
 import google
-import pytest_asyncio
+import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
 
 
 #### Define Utility Functions
@@ -92,17 +95,17 @@ def get_auth_token(client_id: str) -> str:
 
 
 #### Define Fixtures
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def project_id() -> str:
     return get_env_var("GOOGLE_CLOUD_PROJECT")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_version() -> str:
     return get_env_var("TOOLBOX_VERSION")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def tools_file_path(project_id: str) -> Generator[str]:
     """Provides a temporary file path containing the tools manifest."""
     tools_manifest = access_secret_version(
@@ -115,7 +118,7 @@ def tools_file_path(project_id: str) -> Generator[str]:
     os.remove(tools_file_path)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token1(project_id: str) -> str:
     client_id = access_secret_version(
         project_id=project_id, secret_id="sdk_testing_client1"
@@ -123,7 +126,7 @@ def auth_token1(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def auth_token2(project_id: str) -> str:
     client_id = access_secret_version(
         project_id=project_id, secret_id="sdk_testing_client2"
@@ -131,7 +134,7 @@ def auth_token2(project_id: str) -> str:
     return get_auth_token(client_id)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None]:
     """Starts the toolbox server as a subprocess."""
     print("Downloading toolbox binary from gcs bucket...")
@@ -143,20 +146,30 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
         # Make toolbox executable
         os.chmod("toolbox", 0o700)
         # Run toolbox binary
-        toolbox_server = subprocess.Popen(
-            ["./toolbox", "--tools-file", tools_file_path]
+        toolbox_server_1 = subprocess.Popen(
+            ["./toolbox", "--port", "5000", "--tools-file", tools_file_path]
+        )
+        toolbox_server_2 = subprocess.Popen(
+            [
+                "./toolbox",
+                "--port",
+                "5001",
+                "--tools-file",
+                tools_file_path,
+                "--enable-draft-specs",
+            ]
         )
 
         # Wait for server to start
         # Retry logic with a timeout
         for _ in range(5):  # retries
             time.sleep(4)
-            print("Checking if toolbox is successfully started...")
-            if toolbox_server.poll() is None:
-                print("Toolbox server started successfully.")
+            print("Checking if both toolbox servers are successfully started...")
+            if toolbox_server_1.poll() is None and toolbox_server_2.poll() is None:
+                print("Toolbox servers started successfully.")
                 break
         else:
-            raise RuntimeError("Toolbox server failed to start after 5 retries.")
+            raise RuntimeError("Toolbox servers failed to start after 5 retries.")
     except subprocess.CalledProcessError as e:
         print(e.stderr.decode("utf-8"))
         print(e.stdout.decode("utf-8"))
@@ -164,5 +177,31 @@ def toolbox_server(toolbox_version: str, tools_file_path: str) -> Generator[None
     yield
 
     # Clean up toolbox server
-    toolbox_server.terminate()
-    toolbox_server.wait()
+    toolbox_server_1.terminate()
+    toolbox_server_2.terminate()
+    toolbox_server_1.wait()
+    toolbox_server_2.wait()
+
+
+@pytest.fixture(
+    params=[TOOLBOX_SERVER_URL_STABLE, TOOLBOX_SERVER_URL_DRAFT], scope="session"
+)
+def toolbox_server_url(request) -> str:
+    return request.param
+
+
+@pytest.fixture()
+def patch_toolbox_client_url(toolbox_server_url):
+    from toolbox_core.client import ToolboxClient
+
+    original_init = ToolboxClient.__init__
+
+    def new_init(self, url=TOOLBOX_SERVER_URL_STABLE, *args, **kwargs):
+        if url == TOOLBOX_SERVER_URL_STABLE:
+            url = toolbox_server_url
+        original_init(self, url, *args, **kwargs)
+
+    from unittest.mock import patch
+
+    with patch.object(ToolboxClient, "__init__", new_init, create=True):
+        yield

--- a/packages/toolbox-llamaindex/tests/conftest.py
+++ b/packages/toolbox-llamaindex/tests/conftest.py
@@ -29,8 +29,7 @@ import pytest
 from google.auth import compute_engine
 from google.cloud import secretmanager, storage
 
-TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
-TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"
+from tests.constants import TOOLBOX_SERVER_URL_DRAFT, TOOLBOX_SERVER_URL_STABLE
 
 
 #### Define Utility Functions

--- a/packages/toolbox-llamaindex/tests/constants.py
+++ b/packages/toolbox-llamaindex/tests/constants.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOOLBOX_SERVER_URL_STABLE = "http://localhost:5000"
+TOOLBOX_SERVER_URL_DRAFT = "http://localhost:5001"

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -40,6 +40,10 @@ from pydantic import ValidationError
 
 from toolbox_llamaindex.client import ToolboxClient
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
+TOOLBOX_SERVER_URL = "http://localhost:5000"
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")
@@ -47,7 +51,7 @@ class TestE2EClientAsync:
     @pytest.fixture(scope="function")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient("http://localhost:5000")
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
         return toolbox
 
     @pytest_asyncio.fixture(scope="function")
@@ -194,7 +198,7 @@ class TestE2EClientSync:
     @pytest.fixture(scope="session")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient("http://localhost:5000")
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
         return toolbox
 
     @pytest.fixture(scope="function")

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -44,6 +44,8 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
 TOOLBOX_SERVER_URL = "http://localhost:5000"
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -37,12 +37,10 @@ This file covers the following use cases:
 import pytest
 import pytest_asyncio
 from pydantic import ValidationError
+from toolbox_core.protocol import Protocol
 
+from tests.constants import TOOLBOX_SERVER_URL_STABLE
 from toolbox_llamaindex.client import ToolboxClient
-
-pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
-
-TOOLBOX_SERVER_URL = "http://localhost:5000"
 
 pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
@@ -53,7 +51,10 @@ class TestE2EClientAsync:
     @pytest.fixture(scope="function")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
+        # Note: The STABLE URL passed here is automatically patched by the
+        # 'patch_toolbox_client_url' fixture to run against both
+        # the STABLE (5000) and DRAFT (5001) servers.
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
         return toolbox
 
     @pytest_asyncio.fixture(scope="function")
@@ -94,6 +95,14 @@ class TestE2EClientAsync:
         for tool in toolset:
             name = tool._ToolboxTool__core_tool.__name__
             assert name in tool_names
+
+    async def test_aload_toolset_explicit_protocol(self):
+        toolbox = ToolboxClient(
+            TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP_v20251125
+        )
+        toolset = await toolbox.aload_toolset()
+        assert len(toolset) == 7
+        toolbox.close()
 
     async def test_run_tool_async(self, get_n_rows_tool):
         response = await get_n_rows_tool.acall(num_rows="2")
@@ -147,11 +156,14 @@ class TestE2EClientAsync:
             "get-row-by-id-auth",
         )
         auth_tool = tool.add_auth_token_getter("my-test-auth", lambda: auth_token2)
-        with pytest.raises(
-            Exception,
-            match=r"401 \(Unauthorized\)",
-        ):
+        try:
             await auth_tool.acall(id="2")
+            pytest.fail("Expected tool to fail with auth error")
+        except Exception as e:
+            err_str = str(e)
+            assert (
+                "401" in err_str or "-32600" in err_str
+            ), f"Unexpected error message: {err_str}"
 
     async def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""
@@ -200,7 +212,10 @@ class TestE2EClientSync:
     @pytest.fixture(scope="session")
     def toolbox(self):
         """Provides a ToolboxClient instance for each test."""
-        toolbox = ToolboxClient(TOOLBOX_SERVER_URL)
+        # Note: The STABLE URL passed here is automatically patched by the
+        # 'patch_toolbox_client_url' fixture to run against both
+        # the STABLE (5000) and DRAFT (5001) servers.
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
         return toolbox
 
     @pytest.fixture(scope="function")
@@ -241,6 +256,14 @@ class TestE2EClientSync:
         for tool in toolset:
             name = tool._ToolboxTool__core_tool.__name__
             assert name in tool_names
+
+    def test_load_toolset_explicit_protocol(self):
+        toolbox = ToolboxClient(
+            TOOLBOX_SERVER_URL_STABLE, protocol=Protocol.MCP_v20251125
+        )
+        toolset = toolbox.load_toolset()
+        assert len(toolset) == 7
+        toolbox.close()
 
     @pytest.mark.asyncio
     async def test_run_tool_async(self, get_n_rows_tool):
@@ -294,11 +317,14 @@ class TestE2EClientSync:
             "get-row-by-id-auth",
         )
         auth_tool = tool.add_auth_token_getter("my-test-auth", lambda: auth_token2)
-        with pytest.raises(
-            Exception,
-            match=r"401 \(Unauthorized\)",
-        ):
+        try:
             auth_tool.call(id="2")
+            pytest.fail("Expected tool to fail with auth error")
+        except Exception as e:
+            err_str = str(e)
+            assert (
+                "401" in err_str or "-32600" in err_str
+            ), f"Unexpected error message: {err_str}"
 
     def test_run_tool_auth(self, toolbox, auth_token1):
         """Tests running a tool with correct auth."""


### PR DESCRIPTION
## Description

This PR introduces support for the MCP 2026 stateless draft and associated protocol-level enhancements. The most significant additions include stateless transport support, HTTP routing headers, and robust protocol auto-negotiation mechanisms for seamless backwards compatibility.

### Changes
* **Stateless MCP Support (SEP-2575)**: Implements reference support for the new `DRAFT-2026-v1` stateless transport protocol.
* **Protocol Version Auto-Negotiation & Fallback**: 
  * Introduces automatic protocol version negotiation for backwards compatibility.
  * Adds support for a user-defined custom fallback protocols array in `ToolboxClient`.
  * Handles appropriate error codes (`-32022`) for protocol version mismatch and graceful fallback across all MCP transports.
* **Routing Headers (SEP-2243)**: Implements routing header support for the HTTP transport.
* **Testing Enhancements**: 
  * Upgrades integration test harnesses for dual-server execution (testing against stable and new server implementations).
