### PR TITLE
feat(core): implement SEP-2243 routing headers for HTTP transport

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -40,6 +40,16 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
         req_headers = dict(headers or {})
         req_headers["MCP-Protocol-Version"] = self._protocol_version
 
+        # Inject SEP-2243 routing headers
+        req_headers["Mcp-Method"] = request.method
+        if (
+            request.method == "tools/call"
+            and hasattr(request, "params")
+            and request.params is not None
+        ):
+            if hasattr(request.params, "name"):
+                req_headers["Mcp-Name"] = request.params.name
+
         # Dynamically update the _meta protocol version in the parameters model
         if hasattr(request, "params") and request.params is not None:
             if (

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -128,6 +128,39 @@ class TestMcpHttpTransportV20260618:
         call_args = transport._session.post.call_args
         headers = call_args.kwargs["headers"]
         assert headers["MCP-Protocol-Version"] == "DRAFT-2026-v1"
+        assert headers["Mcp-Method"] == "method"
+        assert "Mcp-Name" not in headers
+
+    async def test_send_request_adds_mcp_name_header(self, transport):
+        """Test that the Mcp-Name header is added for tools/call."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestParams(types.BaseModel):
+            name: str
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "tools/call"
+            params: TestParams
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request(
+            "url", TestRequest(params=TestParams(name="test_tool"))
+        )
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["Mcp-Method"] == "tools/call"
+        assert headers["Mcp-Name"] == "test_tool"
 
     # --- Version Negotiation Tests ---
 


### PR DESCRIPTION
## Overview

This PR implements the client-side requirements for [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization) by injecting the required routing headers into the HTTP transport layer for the draft protocol version.

The server relies on these headers to route stateless HTTP requests efficiently without parsing the JSON-RPC body up front.
- Added `Mcp-Method` injection for all HTTP requests made using the `v20260618` protocol transport.
- Added conditional `Mcp-Name` injection specifically for `tools/call`, `prompts/get` and `resources/read`.
- Added test coverage in `test_v20260618.py` to assert the presence and correctness of these headers.