### PR TITLE
feat(core): add support for MCP 2026 stateless draft and auto-negotiation fallback

### DIFF
--- a/packages/toolbox-adk/src/toolbox_adk/tool.py
+++ b/packages/toolbox-adk/src/toolbox_adk/tool.py
@@ -17,11 +17,7 @@ import logging
 from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
 
 import toolbox_core
-from fastapi.openapi.models import (
-    OAuth2,
-    OAuthFlowAuthorizationCode,
-    OAuthFlows,
-)
+from fastapi.openapi.models import OAuth2, OAuthFlowAuthorizationCode, OAuthFlows
 from google.adk.auth.auth_credential import (
     AuthCredential,
     AuthCredentialTypes,

--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -35,6 +35,8 @@ from toolbox_adk import CredentialStrategy, ToolboxTool, ToolboxToolset
 
 TOOLBOX_SERVER_URL = "http://localhost:5000"
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 # Ensure TOOLBOX_VERSION is set for the fixture
 if "TOOLBOX_VERSION" not in os.environ:
     os.environ["TOOLBOX_VERSION"] = "0.0.1"  # Use a valid version or mock

--- a/packages/toolbox-adk/tests/unit/test_credentials.py
+++ b/packages/toolbox-adk/tests/unit/test_credentials.py
@@ -109,10 +109,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_api_key(self):
         from fastapi.openapi.models import APIKey, APIKeyIn
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.API_KEY, api_key="abc"
@@ -129,10 +126,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_api_key_default_location(self):
         from fastapi.openapi.models import APIKey
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.API_KEY, api_key="abc"
@@ -157,10 +151,7 @@ class TestCredentialStrategy:
     def test_from_adk_credentials_api_key_query_fail(self):
         import pytest
         from fastapi.openapi.models import APIKey, APIKeyIn
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         cred = AuthCredential(auth_type=AuthCredentialTypes.API_KEY, api_key="abc")
         scheme = APIKey(type="apiKey", name="key", **{"in": APIKeyIn.query})
@@ -172,10 +163,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_api_key_no_scheme_raises(self):
         import pytest
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.API_KEY, api_key="my-key"
@@ -187,10 +175,7 @@ class TestCredentialStrategy:
 
     def test_from_adk_credentials_unsupported(self):
         import pytest
-        from google.adk.auth.auth_credential import (
-            AuthCredential,
-            AuthCredentialTypes,
-        )
+        from google.adk.auth.auth_credential import AuthCredential, AuthCredentialTypes
 
         auth_credential = AuthCredential(
             auth_type=AuthCredentialTypes.OAUTH2

--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -63,7 +63,7 @@ class _McpTransportProxy(ITransport):
 
     def _create_transport(self, protocol: Protocol) -> ITransport:
         match protocol:
-            case Protocol.MCP_v20260618:
+            case Protocol.MCP_DRAFT:
                 return McpHttpTransportV20260618(
                     self._url,
                     self._session,
@@ -187,12 +187,6 @@ class ToolboxClient:
             client_version: Optional client version for identification.
             telemetry_enabled: Whether to enable OpenTelemetry tracing and metrics. (Default: False)
         """
-
-        if protocol != Protocol.MCP_LATEST:
-            logging.warning(
-                f"A newer version of MCP ({Protocol.MCP_LATEST.value}) is available. "
-                "Please use Protocol.MCP_LATEST to use the latest features."
-            )
 
         self.__transport = _McpTransportProxy(
             url,

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -18,6 +18,7 @@ from typing import Mapping, Optional, TypeVar
 from pydantic import BaseModel
 
 from ... import version
+from ...exceptions import ProtocolNegotiationError
 from ...protocol import ManifestSchema, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
@@ -131,9 +132,7 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    f"MCP version mismatch: client does not support server version {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import time
-from typing import Mapping, Optional, TypeVar
+from typing import Any, Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
 
 from ... import version
+from ...exceptions import ProtocolNegotiationError
 from ...protocol import ManifestSchema, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
@@ -29,7 +30,7 @@ ReceiveResultT = TypeVar("ReceiveResultT", bound=BaseModel)
 class McpHttpTransportV20250326(_McpHttpTransportBase):
     """Transport for the MCP v2025-03-26 protocol."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._session_id: Optional[str] = None
 
@@ -147,10 +148,7 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    "MCP version mismatch: client does not support server version"
-                    f" {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -18,7 +18,8 @@ from typing import Mapping, Optional, TypeVar
 from pydantic import BaseModel
 
 from ... import version
-from ...protocol import ManifestSchema, TelemetryAttributes
+from ...exceptions import ProtocolNegotiationError
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
 from . import types
@@ -71,6 +72,21 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
 
             # Check for JSON-RPC Error
             if "error" in json_resp:
+                err_val = json_resp["error"]
+                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = Protocol.get_supported_mcp_versions()
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
                     raise RuntimeError(
@@ -138,10 +154,7 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    "MCP version mismatch: client does not support server version"
-                    f" {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
@@ -18,7 +18,8 @@ from typing import Mapping, Optional, TypeVar
 from pydantic import BaseModel
 
 from ... import version
-from ...protocol import ManifestSchema, TelemetryAttributes
+from ...exceptions import ProtocolNegotiationError
+from ...protocol import ManifestSchema, Protocol, TelemetryAttributes
 from .. import telemetry
 from ..transport_base import _McpHttpTransportBase
 from . import types
@@ -71,6 +72,21 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
 
             # Check for JSON-RPC Error
             if "error" in json_resp:
+                err_val = json_resp["error"]
+                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = Protocol.get_supported_mcp_versions()
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
                     raise RuntimeError(
@@ -138,10 +154,7 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
             self._server_version = result.serverInfo.version
 
             if result.protocolVersion != self._protocol_version:
-                raise RuntimeError(
-                    "MCP version mismatch: client does not support server version"
-                    f" {result.protocolVersion}"
-                )
+                raise ProtocolNegotiationError(result.protocolVersion)
 
             if not result.capabilities.tools:
                 if self._manage_session:

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -42,13 +42,16 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
 
         # Inject SEP-2243 routing headers
         req_headers["Mcp-Method"] = request.method
-        if (
-            request.method == "tools/call"
-            and hasattr(request, "params")
-            and request.params is not None
-        ):
-            if hasattr(request.params, "name"):
-                req_headers["Mcp-Name"] = request.params.name
+        params = getattr(request, "params", None)
+        if params is not None:
+            if request.method in ("tools/call", "prompts/get"):
+                name = getattr(params, "name", None)
+                if name is not None:
+                    req_headers["Mcp-Name"] = str(name)
+            elif request.method == "resources/read":
+                uri = getattr(params, "uri", None)
+                if uri is not None:
+                    req_headers["Mcp-Name"] = str(uri)
 
         # Dynamically update the _meta protocol version in the parameters model
         if hasattr(request, "params") and request.params is not None:
@@ -125,6 +128,21 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
 
             # Check for JSON-RPC Error
             if "error" in json_resp:
+                err_val = json_resp["error"]
+                if isinstance(err_val, dict) and err_val.get("code") == -32004:
+                    server_supported = err_val.get("data", {}).get("supported", [])
+                    client_supported = Protocol.get_supported_mcp_versions()
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        raise ProtocolNegotiationError(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports: {server_supported}"
+                        )
                 try:
                     err = types.JSONRPCError.model_validate(json_resp).error
                     raise RuntimeError(

--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -47,19 +47,21 @@ class TelemetryAttributes(BaseModel):
 class Protocol(str, Enum):
     """Defines how the client should choose between communication protocols."""
 
-    MCP_v20260618 = "DRAFT-2026-v1"
     MCP_v20250618 = "2025-06-18"
     MCP_v20250326 = "2025-03-26"
     MCP_v20241105 = "2024-11-05"
     MCP_v20251125 = "2025-11-25"
-    MCP = MCP_v20250618
-    MCP_LATEST = MCP_v20260618
+    MCP_v2026_DRAFT = "DRAFT-2026-v1"
+
+    MCP = MCP_v20251125
+    MCP_LATEST = MCP_v20251125
+    MCP_DRAFT = MCP_v2026_DRAFT
 
     @staticmethod
     def get_supported_mcp_versions() -> list[str]:
         """Returns a list of supported MCP protocol versions."""
         return [
-            Protocol.MCP_v20260618.value,
+            Protocol.MCP_DRAFT.value,
             Protocol.MCP_v20251125.value,
             Protocol.MCP_v20250618.value,
             Protocol.MCP_v20250326.value,

--- a/packages/toolbox-core/tests/conformance/client.py
+++ b/packages/toolbox-core/tests/conformance/client.py
@@ -50,7 +50,7 @@ async def main():
 
     protocol = Protocol.MCP
     if scenario == "request-metadata":
-        protocol = Protocol.MCP_v20260618
+        protocol = Protocol.MCP_LATEST
 
     async with ToolboxClient(
         server_url, client_headers=client_headers, protocol=protocol

--- a/packages/toolbox-core/tests/mcp_transport/test_v20241105.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20241105.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.mcp_transport.v20241105 import types
 from toolbox_core.mcp_transport.v20241105.mcp import McpHttpTransportV20241105
 from toolbox_core.protocol import ManifestSchema, Protocol
@@ -248,7 +249,7 @@ class TestMcpHttpTransportV20241105:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="MCP version mismatch"):
+        with pytest.raises(ProtocolNegotiationError):
             await transport._initialize_session()
 
     async def test_initialize_session_missing_tools_capability(self, transport, mocker):

--- a/packages/toolbox-core/tests/mcp_transport/test_v20250618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20250618.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.mcp_transport.v20250618 import types
 from toolbox_core.mcp_transport.v20250618.mcp import McpHttpTransportV20250618
 from toolbox_core.protocol import ManifestSchema, Protocol, TelemetryAttributes
@@ -256,7 +257,7 @@ class TestMcpHttpTransportV20250618:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="MCP version mismatch"):
+        with pytest.raises(ProtocolNegotiationError):
             await transport._initialize_session()
 
     async def test_initialize_session_missing_tools_capability(self, transport, mocker):

--- a/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
 
+from toolbox_core.exceptions import ProtocolNegotiationError
 from toolbox_core.mcp_transport.v20251125 import types
 from toolbox_core.mcp_transport.v20251125.mcp import McpHttpTransportV20251125
 from toolbox_core.protocol import ManifestSchema, Protocol
@@ -256,7 +257,7 @@ class TestMcpHttpTransportV20251125:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="MCP version mismatch"):
+        with pytest.raises(ProtocolNegotiationError):
             await transport._initialize_session()
 
     async def test_initialize_session_missing_tools_capability(self, transport, mocker):

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -70,7 +70,7 @@ async def transport(request, mocker):
     transport = McpHttpTransportV20260618(
         "http://fake-server.com",
         session=mock_session,
-        protocol=Protocol.MCP_v20260618,
+        protocol=Protocol.MCP_DRAFT,
         telemetry_enabled=request.param,
     )
     yield transport
@@ -131,7 +131,7 @@ class TestMcpHttpTransportV20260618:
         assert headers["Mcp-Method"] == "method"
         assert "Mcp-Name" not in headers
 
-    async def test_send_request_adds_mcp_name_header(self, transport):
+    async def test_send_request_adds_mcp_name_header_for_tools_call(self, transport):
         """Test that the Mcp-Name header is added for tools/call."""
         mock_response = AsyncMock()
         mock_response.ok = True
@@ -162,6 +162,70 @@ class TestMcpHttpTransportV20260618:
         assert headers["Mcp-Method"] == "tools/call"
         assert headers["Mcp-Name"] == "test_tool"
 
+    async def test_send_request_adds_mcp_name_header_for_prompts_get(self, transport):
+        """Test that the Mcp-Name header is added for prompts/get."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestParams(types.BaseModel):
+            name: str
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "prompts/get"
+            params: TestParams
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request(
+            "url", TestRequest(params=TestParams(name="test_prompt"))
+        )
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["Mcp-Method"] == "prompts/get"
+        assert headers["Mcp-Name"] == "test_prompt"
+
+    async def test_send_request_adds_mcp_name_header_for_resources_read(
+        self, transport
+    ):
+        """Test that the Mcp-Name header is added for resources/read."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestParams(types.BaseModel):
+            uri: str
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "resources/read"
+            params: TestParams
+
+            def get_result_model(self):
+                return TestResult
+
+        await transport._send_request(
+            "url", TestRequest(params=TestParams(uri="file:///test.txt"))
+        )
+
+        call_args = transport._session.post.call_args
+        headers = call_args.kwargs["headers"]
+        assert headers["Mcp-Method"] == "resources/read"
+        assert headers["Mcp-Name"] == "file:///test.txt"
+
     # --- Version Negotiation Tests ---
 
     async def test_version_negotiation_raises_fallback(self, transport):
@@ -171,6 +235,44 @@ class TestMcpHttpTransportV20260618:
         mock_response_reject = AsyncMock()
         mock_response_reject.ok = False
         mock_response_reject.status = 400
+        mock_response_reject.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "error": {
+                "code": -32004,
+                "message": "Unsupported protocol version",
+                "data": {"supported": ["DRAFT-2026-v1"]},
+            },
+        }
+
+        transport._session.post.return_value.__aenter__.return_value = (
+            mock_response_reject
+        )
+
+        class TestResult(types.BaseModel):
+            pass
+
+        class TestRequest(types.MCPRequest[TestResult]):
+            method: str = "method"
+            params: dict = {}
+
+            def get_result_model(self):
+                return TestResult
+
+        with pytest.raises(ProtocolNegotiationError) as exc_info:
+            await transport._send_request("url", TestRequest())
+
+        assert exc_info.value.negotiated_version == "DRAFT-2026-v1"
+        assert transport._session.post.call_count == 1
+
+    async def test_version_negotiation_raises_fallback_200_ok(self, transport):
+        """Tests that the client raises ProtocolNegotiationError when the server returns 200 OK with -32004."""
+        from toolbox_core.exceptions import ProtocolNegotiationError
+
+        mock_response_reject = AsyncMock()
+        mock_response_reject.ok = True
+        mock_response_reject.status = 200
+        mock_response_reject.content.at_eof = MagicMock(return_value=False)
         mock_response_reject.json.return_value = {
             "jsonrpc": "2.0",
             "id": "1",

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -276,9 +276,7 @@ async def test_load_tool_protocol_fallback_success(test_tool_str):
         mock_2025.tool_invoke.return_value = "ok_from_fallback"
         mock_2025_cls.return_value = mock_2025
 
-        async with ToolboxClient(
-            TEST_BASE_URL, protocol=Protocol.MCP_v20260618
-        ) as client:
+        async with ToolboxClient(TEST_BASE_URL, protocol=Protocol.MCP_DRAFT) as client:
             # This should trigger the fallback
             loaded_tool = await client.load_tool(TOOL_NAME)
 
@@ -322,9 +320,7 @@ async def test_load_tool_protocol_fallback_infinite_loop_prevention(test_tool_st
         mock_2025.tool_get.side_effect = ProtocolNegotiationError("2024-11-05")
         mock_2025_cls.return_value = mock_2025
 
-        async with ToolboxClient(
-            TEST_BASE_URL, protocol=Protocol.MCP_v20260618
-        ) as client:
+        async with ToolboxClient(TEST_BASE_URL, protocol=Protocol.MCP_DRAFT) as client:
             with pytest.raises(
                 ProtocolNegotiationError,
                 match="Server requires protocol fallback to 2024-11-05",
@@ -814,7 +810,7 @@ async def test_client_init_with_client_info():
 def test_toolbox_client_no_warning_on_mcp():
     """Test that initializing ToolboxClient with Protocol.MCP issues NO DeprecationWarning."""
     # Mock the transport to avoid actual connection attempts or MCP version warnings
-    with patch("toolbox_core.client.McpHttpTransportV20250618") as mock_transport:
+    with patch("toolbox_core.client.McpHttpTransportV20251125") as mock_transport:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -26,11 +26,9 @@ from toolbox_core.tool import ToolboxTool
 pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
 
-# TODO: Include draft versions in E2E integration tests once the server
-# supports SEP-2575 (stateless MCP / Request-Metadata).
 @pytest_asyncio.fixture(
     scope="function",
-    params=[v for v in Protocol.get_supported_mcp_versions() if "DRAFT" not in v],
+    params=[v for v in Protocol.get_supported_mcp_versions()],
 )
 async def toolbox(request):
     """Creates a ToolboxClient instance shared by all tests in this module."""
@@ -102,25 +100,26 @@ class TestBasicE2E:
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):
             await get_n_rows_tool()
 
-    async def test_protocol_fallback_e2e(self, toolbox_server_url):
-        """Tests that a client using MCP_LATEST can fallback to an older protocol against a server that doesn't support the latest version."""
-        # The E2E server currently does not support DRAFT 2026, so this will trigger a fallback.
+    async def test_protocol_fallback_e2e(self, toolbox_server_url: str):
+        """Tests that a client using MCP_DRAFT can fallback to an older protocol against a server that doesn't support the draft version."""
+        # The E2E server currently does not support DRAFT 2026 on port 5000, so this will trigger a fallback.
+        # However, port 5001 does support DRAFT 2026.
         async with ToolboxClient(
-            toolbox_server_url, protocol=Protocol.MCP_LATEST
+            toolbox_server_url, protocol=Protocol.MCP_DRAFT
         ) as client:
             tool = await client.load_tool("get-n-rows")
             response = await tool(num_rows="1")
             assert "row1" in response
             # Verify that fallback occurred by checking the transport's final protocol version
-            if "5000" in toolbox_server_url:
+            if "5001" in toolbox_server_url:
                 assert (
                     client._ToolboxClient__transport._protocol_version
-                    != Protocol.MCP_LATEST.value
+                    == Protocol.MCP_DRAFT.value
                 )
             else:
                 assert (
                     client._ToolboxClient__transport._protocol_version
-                    == Protocol.MCP_LATEST.value
+                    != Protocol.MCP_DRAFT.value
                 )
 
     async def test_run_tool_wrong_param_type(self, get_n_rows_tool: ToolboxTool):
@@ -471,3 +470,25 @@ class TestMapParams:
                 execution_context={"env": "staging"},
                 user_scores={"user4": "not-an-integer"},
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("toolbox_server")
+async def test_mcp_default_protocol():
+    """Verify that omitting the protocol argument defaults correctly and works."""
+    async with ToolboxClient("http://localhost:5000") as client:
+        tool = await client.load_tool("get-n-rows")
+        response = await tool(num_rows="1")
+        assert "row1" in response
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("toolbox_server")
+async def test_mcp_draft_fallback():
+    """Verify that explicitly using MCP_DRAFT against a server that doesn't support it falls back successfully."""
+    async with ToolboxClient(
+        "http://localhost:5000", protocol=Protocol.MCP_DRAFT
+    ) as client:
+        tool = await client.load_tool("get-n-rows")
+        response = await tool(num_rows="1")
+        assert "row1" in response

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -412,7 +412,7 @@ def test_tool_init_basic(http_session, sample_tool_params, sample_tool_descripti
     relevant_warnings = [
         w
         for w in record
-        if not issubclass(w.category, (ResourceWarning, DeprecationWarning))
+        if not issubclass(w.category, ResourceWarning)
     ]
     assert (
         len(relevant_warnings) == 0

--- a/packages/toolbox-core/tests/test_tool.py
+++ b/packages/toolbox-core/tests/test_tool.py
@@ -410,9 +410,7 @@ def test_tool_init_basic(http_session, sample_tool_params, sample_tool_descripti
             client_headers={},
         )
     relevant_warnings = [
-        w
-        for w in record
-        if not issubclass(w.category, ResourceWarning)
+        w for w in record if not issubclass(w.category, ResourceWarning)
     ]
     assert (
         len(relevant_warnings) == 0

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -44,6 +44,8 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
 TOOLBOX_SERVER_URL = "http://localhost:5000"
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -44,6 +44,8 @@ pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
 
 TOOLBOX_SERVER_URL = "http://localhost:5000"
 
+pytestmark = pytest.mark.usefixtures("patch_toolbox_client_url")
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("toolbox_server")


### PR DESCRIPTION
## Description

This PR standardizes the Python SDK's version opt-in strategy for the upcoming stateless draft and introduces protocol auto-negotiation fallback to ensure smooth backward compatibility with older servers.

> [!NOTE]
> This PR is stacked on top of the test infrastructure changes in https://github.com/googleapis/mcp-toolbox-sdk-python/pull/706.

## Changes:
*   **Protocol Constants (`protocol.py`):** 
    *   Introduces the `Protocol.MCP_DRAFT` constant mapped to `"DRAFT-2026-v1"` to give developers a safe way to opt into testing the draft spec without hardcoding ephemeral version strings.
    *   Maintains `Protocol.MCP_LATEST` mapped to the stable `2025-11-25` release to ensure production workloads remain unaffected.
*   **Auto-Negotiation Fallback (`client.py` & `mcp.py`):** 
    *   Implements fallback protocol negotiation during client initialization. 
    *   If a client requests the draft protocol but the older server returns a single older version string (instead of throwing a `-32004` `UnsupportedProtocolVersionError`), the transport layer now safely raises a `ProtocolNegotiationError`.
    *   The client catches this error and cleanly re-initializes the session using the older server's preferred protocol.
*   **E2E Testing (`test_e2e_mcp.py`):** 
    *   Adds `test_protocol_fallback_e2e` to verify smooth protocol negotiation downgrades against older servers. Leveraging the dual-server harness from https://github.com/googleapis/mcp-toolbox-sdk-python/pull/706, this test proves that a client requesting `MCP_DRAFT` successfully falls back when hitting port `5000`, but correctly utilizes the draft protocol on port `5001`.
