### PR TITLE
feat(core): preserve query parameters in connection URLs for toolset binding

### DIFF
--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -454,6 +454,29 @@ class TestBasicE2E:
         finally:
             await toolset.close()
 
+    async def test_run_tool_url_binding(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        toolset = ToolboxToolset(
+            server_url=f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2",
+            tool_names=["get-n-rows"],
+            credentials=CredentialStrategy.toolbox_identity(),
+        )
+        try:
+            tools = await toolset.get_tools()
+            tool = tools[0]
+            assert isinstance(tool, ToolboxTool)
+
+            ctx = MagicMock()
+            # 'num_rows' is filtered from the schema and automatically injected by the server
+            response = await tool.run_async({}, ctx)
+
+            assert isinstance(response, str)
+            assert "row1" in response
+            assert "row2" in response
+            assert "row3" not in response
+        finally:
+            await toolset.close()
+
     async def test_run_tool_missing_params(self):
         """Invoke a tool with missing params."""
         toolset = ToolboxToolset(

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import json
+import urllib.parse
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional, Union
 
@@ -44,7 +45,15 @@ class _McpHttpTransportBase(ITransport, ABC):
         telemetry_enabled: bool = False,
         supported_protocols: Optional[list[str]] = None,
     ):
-        self._mcp_base_url = f"{base_url}/mcp/"
+        parsed = urllib.parse.urlparse(base_url)
+        path = parsed.path
+        if path.endswith("/mcp"):
+            path += "/"
+        elif not path.endswith("/mcp/") and "/mcp/" not in path:
+            path = path.rstrip("/") + "/mcp/"
+
+        # Reconstruct the URL with the updated path, preserving query parameters
+        self._mcp_base_url = urllib.parse.urlunparse(parsed._replace(path=path))
         self._protocol_version = protocol.value
         self._server_version: Optional[str] = None
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20241105/mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import urllib.parse
 from typing import Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -240,7 +241,11 @@ class McpHttpTransportV20241105(_McpHttpTransportBase):
         """Lists available tools from the server using the MCP protocol."""
         await self._ensure_initialized(headers=headers)
 
-        url = self._mcp_base_url + (toolset_name if toolset_name else "")
+        url = self._mcp_base_url
+        if toolset_name:
+            parsed = urllib.parse.urlparse(url)
+            new_path = parsed.path.rstrip("/") + "/" + toolset_name
+            url = urllib.parse.urlunparse(parsed._replace(path=new_path))
 
         meta: Optional[types.MCPMeta] = None
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250326/mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import urllib.parse
 from typing import Any, Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -264,7 +265,11 @@ class McpHttpTransportV20250326(_McpHttpTransportBase):
         """Lists available tools from the server using the MCP protocol."""
         await self._ensure_initialized(headers=headers)
 
-        url = self._mcp_base_url + (toolset_name if toolset_name else "")
+        url = self._mcp_base_url
+        if toolset_name:
+            parsed = urllib.parse.urlparse(url)
+            new_path = parsed.path.rstrip("/") + "/" + toolset_name
+            url = urllib.parse.urlunparse(parsed._replace(path=new_path))
 
         meta: Optional[types.MCPMeta] = None
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20250618/mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import urllib.parse
 from typing import Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -245,7 +246,11 @@ class McpHttpTransportV20250618(_McpHttpTransportBase):
         """Lists available tools from the server using the MCP protocol."""
         await self._ensure_initialized(headers=headers)
 
-        url = self._mcp_base_url + (toolset_name if toolset_name else "")
+        url = self._mcp_base_url
+        if toolset_name:
+            parsed = urllib.parse.urlparse(url)
+            new_path = parsed.path.rstrip("/") + "/" + toolset_name
+            url = urllib.parse.urlunparse(parsed._replace(path=new_path))
 
         meta: Optional[types.MCPMeta] = None
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20251125/mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import urllib.parse
 from typing import Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -245,7 +246,11 @@ class McpHttpTransportV20251125(_McpHttpTransportBase):
         """Lists available tools from the server using the MCP protocol."""
         await self._ensure_initialized(headers=headers)
 
-        url = self._mcp_base_url + (toolset_name if toolset_name else "")
+        url = self._mcp_base_url
+        if toolset_name:
+            parsed = urllib.parse.urlparse(url)
+            new_path = parsed.path.rstrip("/") + "/" + toolset_name
+            url = urllib.parse.urlunparse(parsed._replace(path=new_path))
 
         meta: Optional[types.MCPMeta] = None
 

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import urllib.parse
 from typing import Mapping, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -201,7 +202,11 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
         """Lists available tools from the server using the MCP protocol."""
         await self._ensure_initialized(headers=headers)
 
-        url = self._mcp_base_url + (toolset_name if toolset_name else "")
+        url = self._mcp_base_url
+        if toolset_name:
+            parsed = urllib.parse.urlparse(url)
+            new_path = parsed.path.rstrip("/") + "/" + toolset_name
+            url = urllib.parse.urlunparse(parsed._replace(path=new_path))
 
         meta = types.MCPMeta(
             protocol_version=self._protocol_version,

--- a/packages/toolbox-core/tests/mcp_transport/test_base.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_base.py
@@ -69,6 +69,50 @@ class TestMcpHttpTransportBase:
         assert transport._session is not None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "input_url,expected",
+        [
+            ("http://api.com", "http://api.com/mcp/"),
+            ("http://api.com/", "http://api.com/mcp/"),
+            ("http://api.com/mcp", "http://api.com/mcp/"),
+            ("http://api.com/mcp/", "http://api.com/mcp/"),
+            ("http://api.com?proj=xyz", "http://api.com/mcp/?proj=xyz"),
+            ("http://api.com/mcp?proj=xyz", "http://api.com/mcp/?proj=xyz"),
+            ("http://api.com/mcp/?proj=xyz", "http://api.com/mcp/?proj=xyz"),
+            ("http://api.com/v1/api?proj=xyz", "http://api.com/v1/api/mcp/?proj=xyz"),
+            (
+                "http://api.com?proj=xyz&env=prod",
+                "http://api.com/mcp/?proj=xyz&env=prod",
+            ),
+            (
+                "http://api.com/mcp?proj=xyz&env=prod",
+                "http://api.com/mcp/?proj=xyz&env=prod",
+            ),
+            (
+                "http://api.com/mcp?q=a%20b&flag=true",
+                "http://api.com/mcp/?q=a%20b&flag=true",
+            ),
+            ("http://api.com?tag=1&tag=2", "http://api.com/mcp/?tag=1&tag=2"),
+            ("http://localhost:5000/mcp/sse", "http://localhost:5000/mcp/sse"),
+            (
+                "http://localhost:5000/mcp/sse?project=my-project",
+                "http://localhost:5000/mcp/sse?project=my-project",
+            ),
+            (
+                "http://api.com/v1/mcp/sse?proj=xyz",
+                "http://api.com/v1/mcp/sse?proj=xyz",
+            ),
+        ],
+    )
+    async def test_mcp_base_url_construction(self, input_url, expected):
+        """Test that _mcp_base_url is constructed correctly across edge cases."""
+        t = ConcreteTransport(input_url)
+        try:
+            assert t.base_url == expected
+        finally:
+            await t.close()
+
+    @pytest.mark.asyncio
     async def test_ensure_initialized_calls_initialize(self, transport, mocker):
         """Test that _ensure_initialized calls _initialize_session."""
         mocker.patch.object(transport, "_initialize_session", new_callable=AsyncMock)

--- a/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20251125.py
@@ -451,6 +451,33 @@ class TestMcpHttpTransportV20251125:
         assert isinstance(call_args.kwargs["request"], types.ListToolsRequest)
         assert call_args.kwargs["headers"] is None
 
+    async def test_tools_list_with_toolset_name_and_query_params(self, mocker):
+        """Test listing tools with a toolset name when base_url contains query parameters."""
+        mock_session = AsyncMock(spec=ClientSession)
+        transport = McpHttpTransportV20251125(
+            "http://fake-server.com?proj=xyz&env=prod",
+            session=mock_session,
+            protocol=Protocol.MCP_v20251125,
+        )
+        try:
+            mocker.patch.object(
+                transport, "_ensure_initialized", new_callable=AsyncMock
+            )
+            mocker.patch.object(
+                transport,
+                "_send_request",
+                new_callable=AsyncMock,
+                return_value=create_fake_tools_list_result(),
+            )
+            transport._server_version = "1.0.0"
+            manifest = await transport.tools_list(toolset_name="custom_toolset")
+            assert isinstance(manifest, ManifestSchema)
+            expected_url = "http://fake-server.com/mcp/custom_toolset?proj=xyz&env=prod"
+            call_args = transport._send_request.call_args
+            assert call_args.kwargs["url"] == expected_url
+        finally:
+            await transport.close()
+
     async def test_tool_invoke_success(self, transport, mocker):
         mocker.patch.object(transport, "_ensure_initialized", new_callable=AsyncMock)
         mocker.patch.object(

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -354,6 +354,32 @@ class TestMcpHttpTransportV20260618:
         assert isinstance(manifest, ManifestSchema)
         assert "get_weather" in manifest.tools
 
+    async def test_tools_list_with_toolset_name_and_query_params(self, mocker):
+        """Test listing tools with a toolset name when base_url contains query parameters."""
+        mock_session = AsyncMock(spec=ClientSession)
+        transport = McpHttpTransportV20260618(
+            "http://fake-server.com?proj=xyz&env=prod",
+            session=mock_session,
+            protocol=Protocol.MCP_DRAFT,
+        )
+        try:
+            mocker.patch.object(
+                transport, "_ensure_initialized", new_callable=AsyncMock
+            )
+            mocker.patch.object(
+                transport,
+                "_send_request",
+                new_callable=AsyncMock,
+                return_value=create_fake_tools_list_result(),
+            )
+            manifest = await transport.tools_list(toolset_name="custom_toolset")
+            assert isinstance(manifest, ManifestSchema)
+            expected_url = "http://fake-server.com/mcp/custom_toolset?proj=xyz&env=prod"
+            call_args = transport._send_request.call_args
+            assert call_args.kwargs["url"] == expected_url
+        finally:
+            await transport.close()
+
     async def test_tool_invoke_success(self, transport, mocker):
         mocker.patch.object(transport, "_ensure_initialized", new_callable=AsyncMock)
         mocker.patch.object(

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -104,6 +104,19 @@ class TestBasicE2E:
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):
             await get_n_rows_tool()
 
+    async def test_run_tool_url_binding(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        async with ToolboxClient(f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2") as toolbox:
+            tool = await toolbox.load_tool("get-n-rows")
+
+            # 'num_rows' is filtered from the schema and automatically injected by the server
+            response = await tool()
+
+            assert isinstance(response, str)
+            assert "row1" in response
+            assert "row2" in response
+            assert "row3" not in response
+
     async def test_protocol_fallback_e2e(self, toolbox_server_url: str):
         """Tests that a client using MCP_DRAFT can fallback to an older protocol against a server that doesn't support the draft version."""
         # The stable server currently does not support DRAFT 2026, so this will trigger a fallback.

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -79,6 +79,19 @@ class TestBasicE2E:
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):
             get_n_rows_tool()
 
+    def test_run_tool_url_binding(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        with ToolboxSyncClient(f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2") as toolbox:
+            tool = toolbox.load_tool("get-n-rows")
+
+            # 'num_rows' is filtered from the schema and automatically injected by the server
+            response = tool()
+
+            assert isinstance(response, str)
+            assert "row1" in response
+            assert "row2" in response
+            assert "row3" not in response
+
     def test_run_tool_wrong_param_type(self, get_n_rows_tool: ToolboxSyncTool):
         """Invoke a tool with wrong param type."""
         with pytest.raises(

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -111,6 +111,19 @@ class TestE2EClientAsync:
         assert "row2" in response
         assert "row3" not in response
 
+    async def test_run_tool_url_binding_async(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        toolbox = ToolboxClient(f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2")
+        tool = await toolbox.aload_tool("get-n-rows")
+
+        # 'num_rows' is filtered from the schema and automatically injected by the server
+        response = await tool.ainvoke({})
+
+        assert "row1" in response
+        assert "row2" in response
+        assert "row3" not in response
+        toolbox.close()
+
     async def test_run_tool_sync(self, get_n_rows_tool):
         response = get_n_rows_tool.invoke({"num_rows": "2"})
 
@@ -279,6 +292,19 @@ class TestE2EClientSync:
         assert "row1" in response
         assert "row2" in response
         assert "row3" not in response
+
+    def test_run_tool_url_binding_sync(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        toolbox = ToolboxClient(f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2")
+        tool = toolbox.load_tool("get-n-rows")
+
+        # 'num_rows' is filtered from the schema and automatically injected by the server
+        response = tool.invoke({})
+
+        assert "row1" in response
+        assert "row2" in response
+        assert "row3" not in response
+        toolbox.close()
 
     def test_run_tool_missing_params(self, get_n_rows_tool):
         with pytest.raises(ValidationError, match="Field required"):

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -111,6 +111,19 @@ class TestE2EClientAsync:
         assert "row2" in response.content
         assert "row3" not in response.content
 
+    async def test_run_tool_url_binding_async(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        toolbox = ToolboxClient(f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2")
+        tool = await toolbox.aload_tool("get-n-rows")
+
+        # 'num_rows' is filtered from the schema and automatically injected by the server
+        response = await tool.acall()
+
+        assert "row1" in response.content
+        assert "row2" in response.content
+        assert "row3" not in response.content
+        toolbox.close()
+
     async def test_run_tool_sync(self, get_n_rows_tool):
         response = get_n_rows_tool.call(num_rows="2")
 
@@ -279,6 +292,19 @@ class TestE2EClientSync:
         assert "row1" in response.content
         assert "row2" in response.content
         assert "row3" not in response.content
+
+    def test_run_tool_url_binding_sync(self):
+        """Tests URL Parameter Binding natively handled by the server."""
+        toolbox = ToolboxClient(f"{TOOLBOX_SERVER_URL_STABLE}?num_rows=2")
+        tool = toolbox.load_tool("get-n-rows")
+
+        # 'num_rows' is filtered from the schema and automatically injected by the server
+        response = tool.call()
+
+        assert "row1" in response.content
+        assert "row2" in response.content
+        assert "row3" not in response.content
+        toolbox.close()
 
     def test_run_tool_missing_params(self, get_n_rows_tool):
         with pytest.raises(TypeError, match="missing a required argument: 'num_rows'"):


### PR DESCRIPTION
## Overview
This PR adds a feature in the Python SDKs to support URL Parameter Binding. Previously initializing a client with a `server_url` containing query parameters would result in a corrupted URL. The SDKs naively appended paths (like `/mcp/` or the `toolset_name`) to the end of the full URL string, which broke native URL parameter binding when communicating with the server.

## Changes
* Replaced raw string concatenation with `urllib.parse` logic in base transport.
* Updated the `tools_list` method across all supported MCP protocol versions (`v20241105`, `v20250326`, `v20250618`, `v20251125`, `v20260618`) to safely mutate the URL path while fully preserving query strings.
* Added parameterized unit tests covering URL construction edge cases (trailing slashes, existing paths, query parameters).
* Added integration tests verifying URL parameter binding functionality for all packages.
