### PR TITLE
fix(ci): paginate issue listing in weekly sdk tier assessment

### DIFF
--- a/.github/workflows/nightly_tier_report.yml
+++ b/.github/workflows/nightly_tier_report.yml
@@ -67,13 +67,13 @@ jobs:
             const report = fs.readFileSync('tier_report.txt', 'utf8');
             const title = '[Dashboard: Conformance] Weekly SDK Tier Assessment Failure';
             
-            const prevIssues = await github.rest.issues.listForRepo({
+            const prevIssues = await github.paginate(github.rest.issues.listForRepo, {
               ...context.repo,
               state: 'open'
             });
             
             // Find any open issue matching the exact dashboard title
-            let existingIssue = prevIssues.data.find(issue => issue.title === title);
+            let existingIssue = prevIssues.find(issue => issue.title === title);
             
             if (report.includes('Tier Assessment: Tier 1')) {
               console.log('Tier 1 achieved! Closing open issue if it exists.');


### PR DESCRIPTION
## Overview
Fixes a bug in the `Weekly SDK Tier Assessment` workflow where older open assessment issues were not found, leading to duplicate issue creation.

## Problem
The workflow calls `github.rest.issues.listForRepo` directly without pagination. The GitHub REST API defaults to returning only the first 30 open issues (sorted descending by creation date).

For repositories with a high number of open issues, older SDK assessment issues are pushed beyond the first page and are not returned in the result. Consequently, the workflow fails to find the existing open issue and creates a new one instead of updating it.

## Solution
Replaced the direct `github.rest.issues.listForRepo` call with `github.paginate(github.rest.issues.listForRepo, ...)` to retrieve all open issues in the repository before searching for the matching title. This aligns the issue checking with the pattern already used in `cloud_build_failure_reporter.yml`.

> [!NOTE]
> The corresponding change in Toolbox server is in https://github.com/googleapis/mcp-toolbox/pull/3658.