### PR TITLE
feat(core): support multi-step cascading fallback loop in client

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -64,6 +64,7 @@ class _McpTransportProxy(ITransport):
         self._active_transport = self._create_transport(protocol)
 
     def _create_transport(self, protocol: Protocol) -> ITransport:
+        self._current_protocol = protocol
         match protocol:
             case Protocol.MCP_DRAFT:
                 return McpHttpTransportV20260618(
@@ -125,50 +126,57 @@ class _McpTransportProxy(ITransport):
     @property
     def _protocol_version(self) -> str:
         # We must expose this for tests asserting the current protocol version.
-        return getattr(self._active_transport, "_protocol_version", "")
+        if hasattr(self, "_current_protocol") and self._current_protocol:
+            return self._current_protocol.value
+        return str(getattr(self._active_transport, "_protocol_version", ""))
 
     async def _execute_with_fallback(
         self, method_name: str, *args: Any, **kwargs: Any
     ) -> Any:
-        try:
-            return await getattr(self._active_transport, method_name)(*args, **kwargs)
-        except ProtocolNegotiationError as e:
-            server_version = e.negotiated_version
-            all_versions = Protocol.get_supported_mcp_versions()
-
+        while True:
             try:
-                server_idx = all_versions.index(server_version)
-            except ValueError:
-                raise RuntimeError(
-                    f"Server returned unknown protocol version: {server_version}"
+                return await getattr(self._active_transport, method_name)(
+                    *args, **kwargs
                 )
+            except ProtocolNegotiationError as e:
+                server_version = e.negotiated_version
+                all_versions = Protocol.get_supported_mcp_versions()
 
-            # Artificial Array: Server supports this version and all older ones
-            server_supported = all_versions[server_idx:]
-
-            if self._supported_protocols:
-                client_supported = self._supported_protocols
-                mutually_supported = [
-                    v for v in client_supported if v in server_supported
-                ]
-                if mutually_supported:
-                    fallback_protocol = Protocol(mutually_supported[0])
-                else:
+                try:
+                    server_idx = all_versions.index(server_version)
+                except ValueError:
                     raise RuntimeError(
-                        "No mutually supported protocol version. "
-                        f"Client supports: {client_supported}, "
-                        f"Server supports (and older): {server_version}"
+                        f"Server returned unknown protocol version: {server_version}"
                     )
-            else:
-                fallback_protocol = Protocol(server_version)
 
-            logging.warning(
-                f"Protocol fallback required. Switching from "
-                f"{self._protocol_version} to {fallback_protocol.value}"
-            )
-            await self._active_transport.close()
-            self._active_transport = self._create_transport(fallback_protocol)
-            return await getattr(self._active_transport, method_name)(*args, **kwargs)
+                # Artificial Array: Server supports this version and all older ones
+                server_supported = all_versions[server_idx:]
+
+                if self._supported_protocols:
+                    client_supported = self._supported_protocols
+                    mutually_supported = [
+                        v for v in client_supported if v in server_supported
+                    ]
+                    if mutually_supported:
+                        fallback_protocol = Protocol(mutually_supported[0])
+                    else:
+                        raise RuntimeError(
+                            "No mutually supported protocol version. "
+                            f"Client supports: {client_supported}, "
+                            f"Server supports (and older): {server_version}"
+                        )
+                else:
+                    fallback_protocol = Protocol(server_version)
+
+                if fallback_protocol.value == self._protocol_version:
+                    raise e
+
+                logging.warning(
+                    f"Protocol fallback required. Switching from "
+                    f"{self._protocol_version} to {fallback_protocol.value}"
+                )
+                await self._active_transport.close()
+                self._active_transport = self._create_transport(fallback_protocol)
 
     async def tool_get(self, *args: Any, **kwargs: Any) -> Any:
         return await self._execute_with_fallback("tool_get", *args, **kwargs)

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -309,6 +309,7 @@ async def test_load_tool_protocol_fallback_infinite_loop_prevention(test_tool_st
     with (
         patch("toolbox_core.client.McpHttpTransportV20260618") as mock_2026_cls,
         patch("toolbox_core.client.McpHttpTransportV20250618") as mock_2025_cls,
+        patch("toolbox_core.client.McpHttpTransportV20241105") as mock_2024_cls,
     ):
 
         mock_2026 = AsyncMock()
@@ -318,9 +319,15 @@ async def test_load_tool_protocol_fallback_infinite_loop_prevention(test_tool_st
 
         mock_2025 = AsyncMock()
         mock_2025.base_url = TEST_BASE_URL
-        # The fallback transport also throws the error
+        # The fallback transport also throws the error trying to fall back to 2024-11-05
         mock_2025.tool_get.side_effect = ProtocolNegotiationError("2024-11-05")
         mock_2025_cls.return_value = mock_2025
+
+        mock_2024 = AsyncMock()
+        mock_2024.base_url = TEST_BASE_URL
+        # The 2024-11-05 transport also throws ProtocolNegotiationError("2024-11-05")
+        mock_2024.tool_get.side_effect = ProtocolNegotiationError("2024-11-05")
+        mock_2024_cls.return_value = mock_2024
 
         async with ToolboxClient(TEST_BASE_URL, protocol=Protocol.MCP_DRAFT) as client:
             with pytest.raises(
@@ -329,9 +336,10 @@ async def test_load_tool_protocol_fallback_infinite_loop_prevention(test_tool_st
             ):
                 await client.load_tool(TOOL_NAME)
 
-            # Assert we tried both, but then let the exception bubble up instead of looping
+            # Assert we tried all steps, but then let the exception bubble up instead of looping infinitely
             mock_2026.tool_get.assert_awaited_once()
             mock_2025.tool_get.assert_awaited_once()
+            mock_2024.tool_get.assert_awaited_once()
 
 
 class TestAuth:
@@ -961,3 +969,42 @@ async def test_modern_smart_fallback():
 
         assert res == "success"
         mock_create.assert_called_with(Protocol.MCP_v20241105)
+
+
+@pytest.mark.asyncio
+async def test_multistep_cascading_fallback():
+    """Multi-step Cascading Fallback Test across three transport versions (Draft -> 20251125 -> 20241105)."""
+    proxy = _McpTransportProxy(
+        "http://mock",
+        None,
+        Protocol.MCP_DRAFT,
+        None,
+        None,
+        False,
+        [
+            Protocol.MCP_DRAFT.value,
+            Protocol.MCP_v20251125.value,
+            Protocol.MCP_v20241105.value,
+        ],
+    )
+
+    t1 = AsyncMock()
+    t1.tool_get.side_effect = ProtocolNegotiationError(Protocol.MCP_v20251125.value)
+
+    t2 = AsyncMock()
+    t2.tool_get.side_effect = ProtocolNegotiationError(Protocol.MCP_v20241105.value)
+
+    t3 = AsyncMock()
+    t3.tool_get.return_value = "success"
+
+    proxy._active_transport = t1
+
+    with patch.object(proxy, "_create_transport") as mock_create:
+        mock_create.side_effect = [t2, t3]
+
+        res = await proxy.tool_get("mock")
+
+        assert res == "success"
+        assert mock_create.call_count == 2
+        assert mock_create.call_args_list[0][0][0] == Protocol.MCP_v20251125
+        assert mock_create.call_args_list[1][0][0] == Protocol.MCP_v20241105


### PR DESCRIPTION
## Description

### Problem
`_execute_with_fallback` used a single `try-except` block. If a request required a multi-step protocol fallback (e.g. `Draft` -> `2025-11-25` -> `2024-11-05`), the second attempt was executed outside the `try` block. A second `ProtocolNegotiationError` was uncaught and crashed the client instead of trying subsequent allowed versions.

### Solution
Wrapped `_execute_with_fallback` in a `while True:` loop. If a fallback transport raises a subsequent `ProtocolNegotiationError`, the loop catches it, resolves the next allowed protocol, recreates the transport, and retries until connection succeeds or all options are exhausted.

### Changes
  * Wrapped `_execute_with_fallback` execution and transport recreation inside a `while True:` loop.
  * Ensures that if a fallback transport raises a subsequent `ProtocolNegotiationError` (e.g. `Draft` -> `2025-11-25` -> `2024-11-05`), the client catches it, resolves the next allowed protocol from the user's list, and continues fallback until success or exhaustion.
  * Added `test_multistep_cascading_fallback` verifying a 3-step transport fallback chain (`Draft` -> `2025-11-25` -> `2024-11-05`).
