### PR TITLE
docs(core): remove outdated protocol negotiation link from README

### DIFF
--- a/packages/toolbox-core/README.md
+++ b/packages/toolbox-core/README.md
@@ -63,7 +63,6 @@ The core package provides a framework-agnostic way to interact with your Toolbox
 - [Authenticating Tools](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#authenticating-tools)
 - [Binding Parameter Values](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#parameter-binding)
 - [OpenTelemetry](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#opentelemetry)
-- [Protocol Negotiation](https://mcp-toolbox.dev/documentation/connect-to/toolbox-sdks/python-sdk/core/#protocol-negotiation)
 
 
 # Contributing


### PR DESCRIPTION
Removes the outdated `Protocol Negotiation` link from the `toolbox-core` README table of contents to align with current documentation paths.