### PR TITLE
feat(core): support response _meta serverInfo and resultType in draft protocol

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/mcp.py
@@ -244,10 +244,17 @@ class McpHttpTransportV20260618(_McpHttpTransportBase):
 
             tools_map = {t["name"]: self._convert_tool_schema(t) for t in result.tools}
 
+            server_version = (
+                result.field_meta.server_info.version
+                if (result.field_meta and result.field_meta.server_info)
+                else "0.0.0"
+            )
+
             return ManifestSchema(
-                serverVersion="1.0.0",
+                serverVersion=server_version,
                 tools=tools_map,
             )
+
         except Exception as e:
             error = e
             raise

--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/types.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260618/types.py
@@ -106,7 +106,22 @@ class MCPMeta(_BaseMCPModel):
     )
 
 
-class ListToolsResult(_BaseMCPModel):
+class MCPResultMeta(_BaseMCPModel):
+    """Metadata carried in _meta block for responses."""
+
+    server_info: Implementation | None = Field(
+        default=None, alias="io.modelcontextprotocol/serverInfo"
+    )
+
+
+class MCPResult(_BaseMCPModel):
+    """Base model for all MCP results in draft specification."""
+
+    result_type: str = Field(default="complete", alias="resultType")
+    field_meta: MCPResultMeta | None = Field(default=None, alias="_meta")
+
+
+class ListToolsResult(MCPResult):
     tools: list[dict[str, Any]]
 
 
@@ -115,7 +130,7 @@ class TextContent(_BaseMCPModel):
     text: str
 
 
-class CallToolResult(_BaseMCPModel):
+class CallToolResult(MCPResult):
     content: list[TextContent]
     isError: bool = False
 

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260618.py
@@ -468,3 +468,110 @@ class TestMcpHttpTransportV20260618:
 
         assert exc_info.value.negotiated_version == Protocol.MCP_v20251125
         assert transport._session.post.call_count == 1
+
+    # --- Spec Compliance & Metadata Tests (SEP-2575) ---
+
+    async def test_result_meta_parsing_server_info(self, transport):
+        """Test parsing of _meta with io.modelcontextprotocol/serverInfo in result."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.status = 200
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "resultType": "complete",
+                "tools": [],
+                "_meta": {
+                    "io.modelcontextprotocol/serverInfo": {
+                        "name": "ToolboxServer",
+                        "version": "1.8.0",
+                    }
+                },
+            },
+        }
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        res = await transport._send_request(
+            "http://test.com/mcp",
+            types.ListToolsRequest(
+                params=types.ListToolsRequestParams(
+                    field_meta=types.MCPMeta(
+                        protocol_version="DRAFT-2026-v1",
+                        client_info=types.Implementation(name="test", version="1.0"),
+                        client_capabilities=types.ClientCapabilities(),
+                    )
+                )
+            ),
+        )
+        assert res is not None
+        assert res.result_type == "complete"
+        assert res.field_meta is not None
+        assert res.field_meta.server_info is not None
+        assert res.field_meta.server_info.name == "ToolboxServer"
+        assert res.field_meta.server_info.version == "1.8.0"
+
+    async def test_tools_list_uses_server_info_from_meta(self, transport):
+        """Test that tools_list extracts serverVersion dynamically from _meta."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.status = 200
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "resultType": "complete",
+                "tools": [
+                    {
+                        "name": "sample_tool",
+                        "description": "Sample",
+                        "inputSchema": {"type": "object"},
+                    }
+                ],
+                "_meta": {
+                    "io.modelcontextprotocol/serverInfo": {
+                        "name": "ToolboxServer",
+                        "version": "2.5.0",
+                    }
+                },
+            },
+        }
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        manifest = await transport.tools_list()
+        assert manifest.serverVersion == "2.5.0"
+        assert "sample_tool" in manifest.tools
+
+    async def test_result_meta_optional_server_info(self, transport):
+        """Test that missing _meta or missing serverInfo falls back to default version '0.0.0'."""
+        mock_response = AsyncMock()
+        mock_response.ok = True
+        mock_response.status = 200
+        mock_response.content = Mock()
+        mock_response.content.at_eof.return_value = False
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {
+                "resultType": "complete",
+                "tools": [],
+            },
+        }
+        transport._session.post.return_value.__aenter__.return_value = mock_response
+
+        manifest = await transport.tools_list()
+        assert manifest.serverVersion == "0.0.0"
+
+    async def test_result_type_parsing_and_fallback(self, transport):
+        """Test that resultType defaults to 'complete' if missing in response result."""
+        res = types.ListToolsResult.model_validate({"tools": []})
+        assert res.result_type == "complete"
+
+        res_custom = types.ListToolsResult.model_validate(
+            {"tools": [], "resultType": "input_required"}
+        )
+        assert res_custom.result_type == "input_required"


### PR DESCRIPTION
## Overview

This PR aligns the `v20260618` draft MCP transport in `toolbox-core` with the MCP specification ([SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575)). 

It introduces support for parsing server metadata from `_meta["io.modelcontextprotocol/serverInfo"]` on response result objects and dynamically setting `serverVersion` during tool discovery.

## Changes

  * Added `MCPResultMeta` model to parse `_meta["io.modelcontextprotocol/serverInfo"]`.
  * Introduced `MCPResult` base class defining `resultType` (defaulting to `"complete"`) and optional `_meta` metadata.
  * Updated `ListToolsResult` and `CallToolResult` to inherit from `MCPResult`.
  * Updated `tools_list()` to dynamically extract `serverVersion` from `result.field_meta.server_info.version` when available.
  * Added unit tests

> [!IMPORTANT]
> This PR follows up on the corresponding server change in https://github.com/googleapis/mcp-toolbox/pull/3677.
