### PR TITLE
fix(core): allow load_toolset strict success when all params are used

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -493,6 +493,11 @@ class ToolboxClient:
             )
             tools.append(tool)
 
+            # Track usage for both modes. Skipping this under strict=True left
+            # overall-used sets empty and made the final toolset check always fail.
+            overall_used_auth_keys.update(used_auth_keys)
+            overall_used_bound_params.update(used_bound_keys)
+
             if strict:
                 validate_unused_requirements(
                     provided_auth_keys,
@@ -502,9 +507,6 @@ class ToolboxClient:
                     tool_name,
                     is_toolset=False,
                 )
-            else:
-                overall_used_auth_keys.update(used_auth_keys)
-                overall_used_bound_params.update(used_bound_keys)
 
         validate_unused_requirements(
             provided_auth_keys,

--- a/packages/toolbox-core/tests/test_client.py
+++ b/packages/toolbox-core/tests/test_client.py
@@ -516,6 +516,32 @@ class TestValidation:
                 )
 
     @pytest.mark.asyncio
+    async def test_load_toolset_strict_with_fully_used_bound_param_success(
+        self, mock_transport, tool_schema_with_param_P
+    ):
+        """Tests that load_toolset succeeds in strict mode when every tool uses all bound params."""
+        TOOL_P1 = "tool_with_p1"
+        TOOL_P2 = "tool_with_p2"
+        manifest = ManifestSchema(
+            serverVersion="0.0.0",
+            tools={
+                TOOL_P1: tool_schema_with_param_P,
+                TOOL_P2: tool_schema_with_param_P,
+            },
+        )
+        mock_transport.tools_list_mock.return_value = manifest
+
+        async with ToolboxClient(TEST_BASE_URL) as client:
+            client._ToolboxClient__transport = mock_transport
+            tools = await client.load_toolset(
+                bound_params={"param_P": "some_value"}, strict=True
+            )
+
+        assert len(tools) == 2
+        assert {t.__name__ for t in tools} == {TOOL_P1, TOOL_P2}
+        assert all("param_P" not in t.__signature__.parameters for t in tools)
+
+    @pytest.mark.asyncio
     async def test_load_toolset_strict_with_partially_used_bound_param_fail(
         self, mock_transport, tool_schema_with_param_P, tool_schema_minimal
     ):
@@ -558,6 +584,33 @@ class TestValidation:
                 await client.load_toolset(
                     TOOLSET_NAME, bound_params={"param_Z": "some_value"}
                 )
+
+    @pytest.mark.asyncio
+    async def test_load_toolset_strict_with_fully_used_auth_success(
+        self, mock_transport, tool_schema_requires_auth_X
+    ):
+        """Tests that load_toolset succeeds in strict mode when every tool uses all auth tokens."""
+        TOOL_AUTH1 = "tool_with_auth1"
+        TOOL_AUTH2 = "tool_with_auth2"
+        manifest = ManifestSchema(
+            serverVersion="0.0.0",
+            tools={
+                TOOL_AUTH1: tool_schema_requires_auth_X,
+                TOOL_AUTH2: tool_schema_requires_auth_X,
+            },
+        )
+        mock_transport.tools_list_mock.return_value = manifest
+
+        async with ToolboxClient(TEST_BASE_URL) as client:
+            client._ToolboxClient__transport = mock_transport
+            tools = await client.load_toolset(
+                auth_token_getters={"auth_service_X": lambda: "token"}, strict=True
+            )
+
+        assert len(tools) == 2
+        assert {t.__name__ for t in tools} == {TOOL_AUTH1, TOOL_AUTH2}
+        assert all(t._required_authn_params == {} for t in tools)
+        assert all(t._required_authz_tokens == () for t in tools)
 
     @pytest.mark.asyncio
     async def test_load_toolset_strict_with_partially_used_auth_fail(

--- a/packages/toolbox-core/tests/test_sync_client.py
+++ b/packages/toolbox-core/tests/test_sync_client.py
@@ -232,6 +232,110 @@ def test_sync_load_toolset_success(
     assert result1 == f"{TOOL1_NAME}_ok"
 
 
+def test_sync_load_toolset_strict_with_fully_used_bound_param_success(
+    sync_client, mock_transport
+):
+    """Sync path: strict=True succeeds when every tool uses all bound params."""
+    TOOL_P1 = "tool_with_p1"
+    TOOL_P2 = "tool_with_p2"
+    schema = ToolSchema(
+        description="Tool with Parameter P",
+        parameters=[
+            ParameterSchema(name="param_P", type="string", description="Parameter P"),
+        ],
+    )
+    manifest = ManifestSchema(
+        serverVersion="0.0.0", tools={TOOL_P1: schema, TOOL_P2: schema}
+    )
+    mock_transport.tools_list_mock.return_value = manifest
+    sync_client._ToolboxSyncClient__async_client._ToolboxClient__transport = (
+        mock_transport
+    )
+
+    tools = sync_client.load_toolset(
+        bound_params={"param_P": "some_value"}, strict=True
+    )
+
+    assert len(tools) == 2
+    assert {t.__name__ for t in tools} == {TOOL_P1, TOOL_P2}
+    assert all("param_P" not in t.__signature__.parameters for t in tools)
+
+
+def test_sync_load_toolset_strict_with_fully_used_auth_success(
+    sync_client, mock_transport
+):
+    """Sync path: strict=True succeeds when every tool uses all auth tokens."""
+    TOOL_AUTH1 = "tool_with_auth1"
+    TOOL_AUTH2 = "tool_with_auth2"
+    schema = ToolSchema(
+        description="Tool Requiring Auth X",
+        parameters=[
+            ParameterSchema(
+                name="auth_param_X",
+                type="string",
+                description="Auth X Token",
+                authSources=["auth_service_X"],
+            ),
+            ParameterSchema(name="data", type="string", description="Some data"),
+        ],
+    )
+    manifest = ManifestSchema(
+        serverVersion="0.0.0", tools={TOOL_AUTH1: schema, TOOL_AUTH2: schema}
+    )
+    mock_transport.tools_list_mock.return_value = manifest
+    sync_client._ToolboxSyncClient__async_client._ToolboxClient__transport = (
+        mock_transport
+    )
+
+    tools = sync_client.load_toolset(
+        auth_token_getters={"auth_service_X": lambda: "token"}, strict=True
+    )
+
+    assert len(tools) == 2
+    assert {t.__name__ for t in tools} == {TOOL_AUTH1, TOOL_AUTH2}
+    assert all(t._required_authn_params == {} for t in tools)
+    assert all(t._required_authz_tokens == () for t in tools)
+
+
+def test_sync_load_toolset_strict_with_partially_used_auth_fail(
+    sync_client, mock_transport
+):
+    """Sync path: strict=True fails if an auth token is only used by some tools."""
+    TOOL_AUTH = "tool_with_auth"
+    TOOL_MIN = "minimal_tool"
+    schema_auth = ToolSchema(
+        description="Tool Requiring Auth X",
+        parameters=[
+            ParameterSchema(
+                name="auth_param_X",
+                type="string",
+                description="Auth X Token",
+                authSources=["auth_service_X"],
+            ),
+        ],
+    )
+    schema_min = ToolSchema(
+        description="Minimal Test Tool",
+        parameters=[],
+    )
+    manifest = ManifestSchema(
+        serverVersion="0.0.0",
+        tools={TOOL_AUTH: schema_auth, TOOL_MIN: schema_min},
+    )
+    mock_transport.tools_list_mock.return_value = manifest
+    sync_client._ToolboxSyncClient__async_client._ToolboxClient__transport = (
+        mock_transport
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"Validation failed for tool '{TOOL_MIN}': unused auth tokens: auth_service_X.",
+    ):
+        sync_client.load_toolset(
+            auth_token_getters={"auth_service_X": lambda: "token"}, strict=True
+        )
+
+
 def test_sync_invoke_tool_server_error(
     test_tool_str_schema, sync_client, mock_transport
 ):


### PR DESCRIPTION
## Summary

- Fixes `ToolboxClient.load_toolset(..., strict=True)` incorrectly rejecting loads where every provided auth token / bound parameter is used by every tool.
- Root cause: used-key accumulation ran only in the non-strict branch, so the final toolset-level unused-requirement check always saw empty overall-used sets under `strict=True`.
- Adds async and sync regression coverage for the documented strict success path, while keeping existing strict/non-strict failure tests.

🛠️ Fixes #734

## Problem

With a mocked toolset containing a single tool that declares `param_P`:

```python
await client.load_toolset(
    bound_params={"param_P": "some_value"},
    strict=True,
)
```

**Before:** raised

```text
ValueError: Validation failed for toolset 'default': unused bound parameters could not be applied to any tool: param_P.
```

even though the tool used `param_P`. The same false failure occurred for fully used auth token getters.

**After:** loading succeeds, matching the `strict` docstring (fail only when *any* tool fails to use all provided params/tokens).

No GitHub issue was required for permissions reasons beyond standard contribution flow; issue #734 was filed to satisfy the PR template's issue-first checklist.

## Root cause

In `ToolboxClient.load_toolset`, per-tool usage was recorded only in the `else` (non-strict) branch:

```python
if strict:
    validate_unused_requirements(...)  # per-tool
else:
    overall_used_auth_keys.update(...)
    overall_used_bound_params.update(...)

validate_unused_requirements(..., overall_used_*, is_toolset=True)  # always runs
```

Under `strict=True`, `overall_used_*` stayed empty, so the final toolset check treated every provided key as unused.

## Minimal implementation

Always update `overall_used_auth_keys` / `overall_used_bound_params`, then still run the per-tool strict check. Non-strict semantics are unchanged. Sync client inherits the fix via `ToolboxSyncClient.load_toolset`.

## Tests

- `test_load_toolset_strict_with_fully_used_bound_param_success`
- `test_load_toolset_strict_with_fully_used_auth_success`
- `test_sync_load_toolset_strict_with_fully_used_bound_param_success`
- Existing strict partial-use and non-strict unused failure tests still pass

## Validation

From `packages/toolbox-core` with `pip install -e .[test]` (Python 3.12):

- `python -m pytest tests/test_client.py::TestValidation tests/test_sync_client.py::test_sync_load_toolset_strict_with_fully_used_bound_param_success -v` → **9 passed**
- `python -m pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_sync_e2e.py --ignore=tests/test_e2e_mcp.py --ignore=tests/conformance -q --cov=src/toolbox_core --cov-fail-under=90` → **478 passed**, coverage **91.74%**
- `black --check .` → pass
- `isort --check .` → pass
- `MYPYPATH='./src' mypy --install-types --non-interactive -p toolbox_core` → pass
- `git diff --check` → pass

Live Toolbox / GCP integration tests were not run (mocked unit coverage is sufficient for this client validation bug).

## Adapter compatibility

No adapter changes. LangChain / LlamaIndex / ADK call into the same core `load_toolset` path and inherit the corrected strict behavior.

## Non-goals

- Changing strict vs non-strict semantics beyond restoring the documented success path
- MCP `isError` handling, schema conversion, or ADK auth lifecycle (separate candidates)
- Dependency upgrades or docs-only changes

## Test plan

- [x] Unit regression for strict success (bound params + auth) on async client
- [x] Unit regression for strict success on sync client
- [x] Existing strict/non-strict unused validation tests still pass
- [x] Lint (`black`, `isort`) and `mypy` for `toolbox_core`
- [ ] Maintainer-triggered CI (`tests: run` label / `/gcbrun` if needed for fork PRs)
