### PR TITLE
feat(langchain): pass telemetry attributes

### DIFF
--- a/packages/toolbox-langchain/src/toolbox_langchain/async_client.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_client.py
@@ -17,7 +17,7 @@ from warnings import warn
 
 from aiohttp import ClientSession
 from toolbox_core.client import ToolboxClient as ToolboxCoreClient
-from toolbox_core.protocol import Protocol
+from toolbox_core.protocol import Protocol, TelemetryAttributes
 
 from .async_tools import AsyncToolboxTool
 from .version import __version__
@@ -63,6 +63,7 @@ class AsyncToolboxClient:
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
         bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
     ) -> AsyncToolboxTool:
         """
         Loads the tool with the given tool name from the Toolbox service.
@@ -75,6 +76,8 @@ class AsyncToolboxClient:
             auth_headers: Deprecated. Use `auth_token_getters` instead.
             bound_params: An optional mapping of parameter names to their
                 bound values.
+            telemetry_attributes: Optional telemetry attributes (model, user
+                id, agent id) sent to the server with every tool invocation.
 
         Returns:
             A tool loaded from the Toolbox.
@@ -110,6 +113,8 @@ class AsyncToolboxClient:
             auth_token_getters=auth_token_getters,
             bound_params=bound_params,
         )
+        if telemetry_attributes is not None:
+            core_tool = core_tool.add_telemetry_attributes(telemetry_attributes)
         return AsyncToolboxTool(core_tool=core_tool)
 
     async def aload_toolset(
@@ -120,6 +125,7 @@ class AsyncToolboxClient:
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
         bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
         strict: bool = False,
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
     ) -> list[AsyncToolboxTool]:
         """
         Loads tools from the Toolbox service, optionally filtered by toolset
@@ -139,6 +145,8 @@ class AsyncToolboxClient:
                 provided). If False (default), raises an error only if a
                 user-provided parameter or auth token cannot be applied to *any*
                 loaded tool across the set.
+            telemetry_attributes: Optional telemetry attributes (model, user
+                id, agent id) sent to the server with every tool invocation.
 
         Returns:
             A list of all tools loaded from the Toolbox.
@@ -178,6 +186,8 @@ class AsyncToolboxClient:
 
         tools = []
         for core_tool in core_tools:
+            if telemetry_attributes is not None:
+                core_tool = core_tool.add_telemetry_attributes(telemetry_attributes)
             tools.append(AsyncToolboxTool(core_tool=core_tool))
         return tools
 

--- a/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/async_tools.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Union
 
 from deprecated import deprecated
 from langchain_core.tools import BaseTool
+from toolbox_core.protocol import TelemetryAttributes
 from toolbox_core.tool import ToolboxTool as ToolboxCoreTool
 from toolbox_core.utils import params_to_pydantic_model
 
@@ -165,3 +166,21 @@ class AsyncToolboxTool(BaseTool):
             ValueError: If the provided bound param is already bound.
         """
         return self.bind_params({param_name: param_value})
+
+    def add_telemetry_attributes(
+        self, telemetry_attributes: TelemetryAttributes
+    ) -> "AsyncToolboxTool":
+        """
+        Sets telemetry attributes (model, user id, agent id) that are sent to
+        the server with every invocation of the returned tool. A second call
+        replaces (does not merge with) the previous attributes.
+
+        Args:
+            telemetry_attributes: The telemetry attributes to attach.
+
+        Returns:
+            A new AsyncToolboxTool instance that is a deep copy of the current
+            instance, with the telemetry attributes attached.
+        """
+        new_core_tool = self.__core_tool.add_telemetry_attributes(telemetry_attributes)
+        return AsyncToolboxTool(core_tool=new_core_tool)

--- a/packages/toolbox-langchain/src/toolbox_langchain/client.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/client.py
@@ -16,7 +16,7 @@ from asyncio import to_thread
 from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 from warnings import warn
 
-from toolbox_core.protocol import Protocol
+from toolbox_core.protocol import Protocol, TelemetryAttributes
 from toolbox_core.sync_client import ToolboxSyncClient as ToolboxCoreSyncClient
 
 from .tools import ToolboxTool
@@ -57,6 +57,7 @@ class ToolboxClient:
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
         bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
     ) -> ToolboxTool:
         """
         Loads the tool with the given tool name from the Toolbox service.
@@ -69,6 +70,8 @@ class ToolboxClient:
             auth_headers: Deprecated. Use `auth_token_getters` instead.
             bound_params: An optional mapping of parameter names to their
                 bound values.
+            telemetry_attributes: Optional telemetry attributes (model, user
+                id, agent id) sent to the server with every tool invocation.
 
         Returns:
             A tool loaded from the Toolbox.
@@ -105,6 +108,8 @@ class ToolboxClient:
             auth_token_getters=auth_token_getters,
             bound_params=bound_params,
         )
+        if telemetry_attributes is not None:
+            core_tool = core_tool.add_telemetry_attributes(telemetry_attributes)
         return ToolboxTool(core_tool=core_tool)
 
     async def aload_toolset(
@@ -115,6 +120,7 @@ class ToolboxClient:
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
         bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
         strict: bool = False,
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
     ) -> list[ToolboxTool]:
         """
         Loads tools from the Toolbox service, optionally filtered by toolset
@@ -134,6 +140,8 @@ class ToolboxClient:
                 provided). If False (default), raises an error only if a
                 user-provided parameter or auth token cannot be applied to *any*
                 loaded tool across the set.
+            telemetry_attributes: Optional telemetry attributes (model, user
+                id, agent id) sent to the server with every tool invocation.
 
         Returns:
             A list of all tools loaded from the Toolbox.
@@ -174,6 +182,8 @@ class ToolboxClient:
 
         tools = []
         for core_tool in core_tools:
+            if telemetry_attributes is not None:
+                core_tool = core_tool.add_telemetry_attributes(telemetry_attributes)
             tools.append(ToolboxTool(core_tool=core_tool))
         return tools
 
@@ -184,6 +194,7 @@ class ToolboxClient:
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
         bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
     ) -> ToolboxTool:
         """
         Loads the tool with the given tool name from the Toolbox service.
@@ -196,6 +207,8 @@ class ToolboxClient:
             auth_headers: Deprecated. Use `auth_token_getters` instead.
             bound_params: An optional mapping of parameter names to their
                 bound values.
+            telemetry_attributes: Optional telemetry attributes (model, user
+                id, agent id) sent to the server with every tool invocation.
 
         Returns:
             A tool loaded from the Toolbox.
@@ -231,6 +244,10 @@ class ToolboxClient:
             auth_token_getters=auth_token_getters,
             bound_params=bound_params,
         )
+        if telemetry_attributes is not None:
+            core_sync_tool = core_sync_tool.add_telemetry_attributes(
+                telemetry_attributes
+            )
         return ToolboxTool(core_tool=core_sync_tool)
 
     def load_toolset(
@@ -241,6 +258,7 @@ class ToolboxClient:
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
         bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
         strict: bool = False,
+        telemetry_attributes: Optional[TelemetryAttributes] = None,
     ) -> list[ToolboxTool]:
         """
         Loads tools from the Toolbox service, optionally filtered by toolset
@@ -260,6 +278,8 @@ class ToolboxClient:
                 provided). If False (default), raises an error only if a
                 user-provided parameter or auth token cannot be applied to *any*
                 loaded tool across the set.
+            telemetry_attributes: Optional telemetry attributes (model, user
+                id, agent id) sent to the server with every tool invocation.
 
         Returns:
             A list of all tools loaded from the Toolbox.
@@ -299,6 +319,10 @@ class ToolboxClient:
 
         tools = []
         for core_sync_tool in core_sync_tools:
+            if telemetry_attributes is not None:
+                core_sync_tool = core_sync_tool.add_telemetry_attributes(
+                    telemetry_attributes
+                )
             tools.append(ToolboxTool(core_tool=core_sync_tool))
         return tools
 

--- a/packages/toolbox-langchain/src/toolbox_langchain/tools.py
+++ b/packages/toolbox-langchain/src/toolbox_langchain/tools.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Union
 
 from deprecated import deprecated
 from langchain_core.tools import BaseTool
+from toolbox_core.protocol import TelemetryAttributes
 from toolbox_core.sync_tool import ToolboxSyncTool as ToolboxCoreSyncTool
 from toolbox_core.utils import params_to_pydantic_model
 
@@ -151,3 +152,21 @@ class ToolboxTool(BaseTool):
             ValueError: If the provided bound param is already bound.
         """
         return self.bind_params({param_name: param_value})
+
+    def add_telemetry_attributes(
+        self, telemetry_attributes: TelemetryAttributes
+    ) -> "ToolboxTool":
+        """
+        Sets telemetry attributes (model, user id, agent id) that are sent to
+        the server with every invocation of the returned tool. A second call
+        replaces (does not merge with) the previous attributes.
+
+        Args:
+            telemetry_attributes: The telemetry attributes to attach.
+
+        Returns:
+            A new ToolboxTool instance that is a deep copy of the current
+            instance, with the telemetry attributes attached.
+        """
+        new_core_tool = self.__core_tool.add_telemetry_attributes(telemetry_attributes)
+        return ToolboxTool(core_tool=new_core_tool)

--- a/packages/toolbox-langchain/tests/test_async_client.py
+++ b/packages/toolbox-langchain/tests/test_async_client.py
@@ -19,7 +19,7 @@ import pytest
 from aiohttp import ClientSession
 from toolbox_core.client import ToolboxClient as ToolboxCoreClient
 from toolbox_core.protocol import ParameterSchema as CoreParameterSchema
-from toolbox_core.protocol import Protocol
+from toolbox_core.protocol import Protocol, TelemetryAttributes
 from toolbox_core.tool import ToolboxTool as ToolboxCoreTool
 
 from toolbox_langchain.async_client import AsyncToolboxClient
@@ -140,6 +140,30 @@ class TestAsyncToolboxClient:
             tool.name == tool_name
         )  # AsyncToolboxTool gets its name from the core_tool
 
+    async def test_aload_tool_with_telemetry_attributes(self, mock_client):
+        tool_name = "test_tool_1"
+        attrs = TelemetryAttributes(llm_model="gemini-3.5-flash")
+        core_tool = AsyncMock(spec=ToolboxCoreTool)
+        core_tool.__name__ = tool_name
+        core_tool.__doc__ = "Test Tool 1 Description"
+        core_tool._name = tool_name
+        core_tool._params = [
+            CoreParameterSchema(name="param1", type="string", description="Param 1")
+        ]
+        telemetry_core_tool = AsyncMock(spec=ToolboxCoreTool)
+        telemetry_core_tool.__name__ = tool_name
+        telemetry_core_tool.__doc__ = "Test Tool 1 Description"
+        telemetry_core_tool._name = tool_name
+        telemetry_core_tool._params = core_tool._params
+        core_tool.add_telemetry_attributes.return_value = telemetry_core_tool
+        mock_client._AsyncToolboxClient__core_client.load_tool.side_effect = None
+        mock_client._AsyncToolboxClient__core_client.load_tool.return_value = core_tool
+
+        tool = await mock_client.aload_tool(tool_name, telemetry_attributes=attrs)
+
+        core_tool.add_telemetry_attributes.assert_called_once_with(attrs)
+        assert tool._AsyncToolboxTool__core_tool is telemetry_core_tool
+
     async def test_aload_tool_auth_headers_deprecated(self, mock_client):
         tool_name = "test_tool_1"
         auth_lambda = lambda: "Bearer token"
@@ -238,6 +262,31 @@ class TestAsyncToolboxClient:
         for tool in tools:
             assert isinstance(tool, AsyncToolboxTool)
             assert tool.name in ["test_tool_1", "test_tool_2"]
+
+    async def test_aload_toolset_with_telemetry_attributes(self, mock_client):
+        attrs = TelemetryAttributes(llm_model="gemini-3.5-flash")
+        core_tool = AsyncMock(spec=ToolboxCoreTool)
+        core_tool.__name__ = "test_tool_1"
+        core_tool.__doc__ = "Test Tool 1 Description"
+        core_tool._name = "test_tool_1"
+        core_tool._params = [
+            CoreParameterSchema(name="param1", type="string", description="Param 1")
+        ]
+        telemetry_core_tool = AsyncMock(spec=ToolboxCoreTool)
+        telemetry_core_tool.__name__ = "test_tool_1"
+        telemetry_core_tool.__doc__ = "Test Tool 1 Description"
+        telemetry_core_tool._name = "test_tool_1"
+        telemetry_core_tool._params = core_tool._params
+        core_tool.add_telemetry_attributes.return_value = telemetry_core_tool
+        mock_client._AsyncToolboxClient__core_client.load_toolset.side_effect = None
+        mock_client._AsyncToolboxClient__core_client.load_toolset.return_value = [
+            core_tool
+        ]
+
+        tools = await mock_client.aload_toolset(telemetry_attributes=attrs)
+
+        core_tool.add_telemetry_attributes.assert_called_once_with(attrs)
+        assert tools[0]._AsyncToolboxTool__core_tool is telemetry_core_tool
 
     async def test_aload_toolset_with_toolset_name(self, mock_client):
         toolset_name = "test_toolset_1"

--- a/packages/toolbox-langchain/tests/test_async_tools.py
+++ b/packages/toolbox-langchain/tests/test_async_tools.py
@@ -20,6 +20,7 @@ import pytest_asyncio
 from pydantic import ValidationError
 from toolbox_core.itransport import ITransport
 from toolbox_core.protocol import ParameterSchema as CoreParameterSchema
+from toolbox_core.protocol import TelemetryAttributes
 from toolbox_core.tool import ToolboxTool as ToolboxCoreTool
 
 
@@ -300,6 +301,30 @@ class TestAsyncToolboxTool:
         transport = core_tool._ToolboxTool__transport
         transport.tool_invoke_mock.assert_awaited_once_with(
             "test_tool", {"param2": 123}, {"test-auth-source_token": "test-token"}
+        )
+
+    async def test_toolbox_tool_call_with_telemetry_attributes(self, toolbox_tool):
+        attrs = TelemetryAttributes(llm_model="gemini-3.5-flash", user_id="user-1")
+        core_tool = toolbox_tool._AsyncToolboxTool__core_tool
+
+        with patch.object(
+            core_tool,
+            "add_telemetry_attributes",
+            wraps=core_tool.add_telemetry_attributes,
+        ) as mock_add_telemetry_attributes:
+            tool = toolbox_tool.add_telemetry_attributes(attrs)
+
+        mock_add_telemetry_attributes.assert_called_once_with(attrs)
+        result = await tool.ainvoke({"param1": "test-value", "param2": 123})
+
+        assert result == "test-result"
+        derived_core_tool = tool._AsyncToolboxTool__core_tool
+        transport = derived_core_tool._ToolboxTool__transport
+        transport.tool_invoke_mock.assert_awaited_once_with(
+            "test_tool",
+            {"param1": "test-value", "param2": 123},
+            {},
+            telemetry_attributes=attrs,
         )
 
     async def test_toolbox_tool_call_with_invalid_input(self, toolbox_tool):

--- a/packages/toolbox-langchain/tests/test_client.py
+++ b/packages/toolbox-langchain/tests/test_client.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock, patch
 import pytest
 from pydantic import BaseModel
 from toolbox_core.protocol import ParameterSchema as CoreParameterSchema
-from toolbox_core.protocol import Protocol
+from toolbox_core.protocol import Protocol, TelemetryAttributes
 from toolbox_core.sync_tool import ToolboxSyncTool as ToolboxCoreSyncTool
 from toolbox_core.utils import params_to_pydantic_model
 
@@ -170,6 +170,42 @@ class TestToolboxClient:
         mock_core_load_toolset.assert_called_once_with(
             name=None, auth_token_getters={}, bound_params={}, strict=False
         )
+
+    @patch("toolbox_core.sync_client.ToolboxSyncClient.load_tool")
+    def test_load_tool_with_telemetry_attributes(
+        self, mock_core_load_tool, toolbox_client
+    ):
+        mock_core_tool_instance = create_mock_core_sync_tool()
+        telemetry_core_tool = create_mock_core_sync_tool(name="telemetry_tool")
+        mock_core_tool_instance.add_telemetry_attributes.return_value = (
+            telemetry_core_tool
+        )
+        mock_core_load_tool.return_value = mock_core_tool_instance
+        attrs = TelemetryAttributes(llm_model="gemini-3.5-flash")
+
+        langchain_tool = toolbox_client.load_tool(
+            "test_tool", telemetry_attributes=attrs
+        )
+
+        mock_core_tool_instance.add_telemetry_attributes.assert_called_once_with(attrs)
+        assert langchain_tool._ToolboxTool__core_tool is telemetry_core_tool
+
+    @patch("toolbox_core.sync_client.ToolboxSyncClient.load_toolset")
+    def test_load_toolset_with_telemetry_attributes(
+        self, mock_core_load_toolset, toolbox_client
+    ):
+        mock_core_tool_instance = create_mock_core_sync_tool()
+        telemetry_core_tool = create_mock_core_sync_tool(name="telemetry_tool")
+        mock_core_tool_instance.add_telemetry_attributes.return_value = (
+            telemetry_core_tool
+        )
+        mock_core_load_toolset.return_value = [mock_core_tool_instance]
+        attrs = TelemetryAttributes(llm_model="gemini-3.5-flash")
+
+        tools = toolbox_client.load_toolset(telemetry_attributes=attrs)
+
+        mock_core_tool_instance.add_telemetry_attributes.assert_called_once_with(attrs)
+        assert tools[0]._ToolboxTool__core_tool is telemetry_core_tool
 
     @pytest.mark.asyncio
     @patch("toolbox_core.sync_client.ToolboxSyncClient.load_tool")

--- a/packages/toolbox-langchain/tests/test_tools.py
+++ b/packages/toolbox-langchain/tests/test_tools.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 import pytest
 from pydantic import BaseModel
 from toolbox_core.protocol import ParameterSchema as CoreParameterSchema
+from toolbox_core.protocol import TelemetryAttributes
 from toolbox_core.sync_tool import ToolboxSyncTool as ToolboxCoreSyncTool
 from toolbox_core.tool import ToolboxTool as CoreAsyncTool
 from toolbox_core.utils import params_to_pydantic_model
@@ -138,6 +139,9 @@ class TestToolboxTool:
             return_value=new_mock_instance_for_methods
         )
         sync_mock.bind_params = Mock(return_value=new_mock_instance_for_methods)
+        sync_mock.add_telemetry_attributes = Mock(
+            return_value=new_mock_instance_for_methods
+        )
 
         return sync_mock
 
@@ -276,6 +280,16 @@ class TestToolboxTool:
         mock_core_sync_auth_tool.add_auth_token_getters.assert_called_once_with(
             {"test-auth-source": get_id_token}
         )
+        assert isinstance(new_langchain_tool, ToolboxTool)
+        assert new_langchain_tool._ToolboxTool__core_tool == returned_core_tool_mock
+
+    def test_toolbox_tool_add_telemetry_attributes(self, toolbox_tool, mock_core_tool):
+        attrs = TelemetryAttributes(llm_model="gemini-3.5-flash", user_id="user-1")
+        returned_core_tool_mock = mock_core_tool.add_telemetry_attributes.return_value
+
+        new_langchain_tool = toolbox_tool.add_telemetry_attributes(attrs)
+
+        mock_core_tool.add_telemetry_attributes.assert_called_once_with(attrs)
         assert isinstance(new_langchain_tool, ToolboxTool)
         assert new_langchain_tool._ToolboxTool__core_tool == returned_core_tool_mock
 


### PR DESCRIPTION
## Background

`toolbox-core` and `toolbox-adk` now support `TelemetryAttributes`, but LangChain wrappers cannot attach model, user, or agent metadata to Toolbox invocations.

## Changes

- Add `telemetry_attributes` to sync/async `load_tool` and `load_toolset` methods.
- Apply attributes to every loaded core tool before wrapping it.
- Add immutable `add_telemetry_attributes(...)` methods to sync/async LangChain tools.
- Cover client and wrapper paths, including transport-level propagation.

## Related

- Builds on #632 / #634.
- Extends the telemetry integration pattern established for ADK in #720.
- Follows the existing LangChain auth-token getter and bound-parameter wrapper patterns.