### PR TITLE
fix(core): isolate shared initialization cancellation

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -92,7 +92,7 @@ class _McpHttpTransportBase(ITransport, ABC):
                 self._init_task = asyncio.create_task(
                     self._initialize_session(headers=headers)
                 )
-        await self._init_task
+        await asyncio.shield(self._init_task)
 
     @property
     def base_url(self) -> str:

--- a/packages/toolbox-core/tests/mcp_transport/test_base.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_base.py
@@ -152,6 +152,40 @@ class TestMcpHttpTransportBase:
 
         transport._initialize_session.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_cancelled_waiter_does_not_cancel_shared_initialization(self, mocker):
+        """Cancelling one waiter leaves the shared initialization running."""
+        session = AsyncMock(spec=ClientSession)
+        transport = ConcreteTransport("http://fake-server.com", session=session)
+        init_started = asyncio.Event()
+        allow_init = asyncio.Event()
+
+        async def slow_init(*args, **kwargs):
+            init_started.set()
+            await allow_init.wait()
+
+        mocker.patch.object(
+            transport,
+            "_initialize_session",
+            new_callable=AsyncMock,
+            side_effect=slow_init,
+        )
+
+        cancelled_waiter = asyncio.create_task(transport._ensure_initialized())
+        await init_started.wait()
+        surviving_waiter = asyncio.create_task(transport._ensure_initialized())
+        await asyncio.sleep(0)
+
+        cancelled_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_waiter
+
+        allow_init.set()
+        assert await asyncio.gather(surviving_waiter, return_exceptions=True) == [None]
+
+        await transport._ensure_initialized()
+        transport._initialize_session.assert_awaited_once()
+
     def test_convert_tool_schema_valid(self, transport):
         """Test converting a valid MCP tool schema."""
         raw_tool = {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Communicate test infrastructure changes, i.e. API enablement, secrets — no test infrastructure changes
- [x] Appropriate docs were updated (if necessary) — no documentation change is needed for this internal lifecycle correction

🛠️ Fixes #743

## Summary

- Isolate the shared MCP initialization task from cancellation of an individual request waiter.
- Add deterministic regression coverage for concurrent and later initialization waiters.

## Problem

All first MCP requests share one `_init_task` so session initialization runs once. However, `_ensure_initialized()` awaited that task directly. Python therefore propagated cancellation from any waiting request into the shared task.

A minimal reproduction starts two `_ensure_initialized()` waiters while initialization is blocked on an event, then cancels only the first waiter.

Before this change:

```text
first_waiter=cancelled
second_waiter=cancelled
shared_init_cancelled=True
later_initialization=cancelled
```

The cancelled request unintentionally cancelled unrelated concurrent and later requests.

## Root cause

`_McpHttpTransportBase._ensure_initialized()` retained one shared task but used `await self._init_task`. Cancellation of a coroutine awaiting another task is propagated to that task unless it is shielded.

## Solution

Await the retained initialization task through `asyncio.shield()`. The calling request still receives `CancelledError`, while the shared initialization continues for other waiters.

Genuine initialization exceptions are unchanged and still propagate to waiters.

## Tests

- `python -m pytest tests/mcp_transport/test_base.py::TestMcpHttpTransportBase::test_cancelled_waiter_does_not_cancel_shared_initialization -v`
  - Before the fix: failed because the surviving waiter returned `CancelledError`.
  - After the fix: 1 passed.
- `python -m pytest tests/mcp_transport/test_base.py -q` — 38 passed.
- `python -m pytest tests -q --ignore=tests/test_e2e.py --ignore=tests/test_sync_e2e.py --ignore=tests/test_e2e_mcp.py --ignore=tests/conformance --cov=src/toolbox_core --cov-report=term --cov-fail-under=90` — 481 passed, 15 warnings, 91.71% coverage.
- `python -m pytest tests/unit -q` in `toolbox-adk` — 59 passed, 10 dependency deprecation warnings.
- `python -m pytest -k "not e2e" -q` in `toolbox-langchain` — 60 passed, 64 deselected.
- `python -m pytest -k "not e2e" -q` in `toolbox-llamaindex` — 61 passed, 64 deselected.

## Validation

- `black --check .` — passed; 44 files unchanged.
- `isort --check .` — passed.
- `MYPYPATH='./src' mypy --install-types --non-interactive --cache-dir=.mypy_cache/ -p toolbox_core` — passed; no issues in 29 source files.
- `git diff upstream/main...HEAD --check` — passed.
- Live Toolbox/GCP E2E, Cloud Build integration, and MCP conformance were not run locally because they require external services or maintainer-triggered infrastructure.

## Compatibility and risk

There is no public API, schema, serialization, authentication, telemetry, or successful-call behavior change. The change applies uniformly to every MCP protocol implementation through the shared transport base.

Shielding means initialization can finish after the request that first triggered it is cancelled. This is intentional because the task is retained by the transport and may already serve other requests.

## Non-goals

- Retrying genuine initialization failures.
- Changing `close()` cancellation semantics.
- Changing protocol negotiation, schemas, auth, telemetry, or adapter APIs.
- Modifying behavior covered by PRs #735, #736, #737, #740, or #741.

## Documentation

No documentation change is required because this restores internal lifecycle isolation without changing the public interface.

## Related issues and prior work

- Fixes #743.
- Duplicate searches covered open and closed issues and PRs (including comments), repository history, changelogs, and the parent MCP Toolbox repository. No blocking overlap was found.
- This change is independent of PRs #735, #736, #737, #740, and #741 and does not touch their files.

## AI assistance

This issue investigation and patch were prepared with AI assistance. The reproduction, regression sensitivity, diff, and validation results were verified locally against current `upstream/main`.
