### PR TITLE
fix(core): close session after cancelled initialization

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -246,7 +246,7 @@ class _McpHttpTransportBase(ITransport, ABC):
             if self._init_task:
                 try:
                     await self._init_task
-                except Exception:
+                except (asyncio.CancelledError, Exception):
                     # If initialization failed, we can still try to close.
                     pass
         if self._manage_session and self._session and not self._session.closed:

--- a/packages/toolbox-core/tests/mcp_transport/test_base.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_base.py
@@ -316,6 +316,37 @@ class TestMcpHttpTransportBase:
         mock_close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_close_managed_session_after_cancelled_initialization(self):
+        transport = ConcreteTransport("http://fake-server.com")
+        transport._init_task = asyncio.create_task(asyncio.sleep(0))
+        transport._init_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await transport._init_task
+
+        try:
+            await transport.close()
+            assert transport._session.closed
+        finally:
+            if not transport._session.closed:
+                await transport._session.close()
+
+    @pytest.mark.asyncio
+    async def test_close_managed_session_after_initialization_error(self):
+        async def fail_initialization():
+            raise RuntimeError("initialization failed")
+
+        transport = ConcreteTransport("http://fake-server.com")
+        transport._init_task = asyncio.create_task(fail_initialization())
+
+        try:
+            await transport.close()
+            assert transport._session.closed
+        finally:
+            if not transport._session.closed:
+                await transport._session.close()
+
+    @pytest.mark.asyncio
     async def test_close_unmanaged_session(self):
         mock_session = AsyncMock(spec=ClientSession)
         transport = ConcreteTransport("http://fake-server.com", session=mock_session)


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Communicate test infrastructure changes, i.e. API enablement, secrets (none)
- [x] Appropriate docs were updated (not necessary for this internal cleanup fix)

🛠️ Fixes #744

## Summary

Ensure `_McpHttpTransportBase.close()` still closes its internally managed
`aiohttp.ClientSession` when the cached initialization task was cancelled.

## Problem

`asyncio.CancelledError` inherits directly from `BaseException`, so the existing
`except Exception` around the initialization task did not handle cancellation.
Calling `close()` after a cancelled initialization therefore propagated
`CancelledError` before reaching session cleanup, leaving the managed session
open.

## Minimal reproduction

1. Create a core MCP transport that owns its `aiohttp.ClientSession`.
2. Assign and cancel its cached `_init_task`.
3. Await the cancelled task, then call `await transport.close()`.

Before this change, `close()` raises `asyncio.CancelledError` and
`transport._session.closed` remains `False`. After this change, explicit cleanup
completes and the managed session is closed.

## Implementation

- Handle `asyncio.CancelledError` alongside ordinary initialization exceptions
  during explicit transport cleanup.
- Add a regression test proving a cancelled initialization no longer prevents
  the managed session from closing.
- Add adjacent coverage preserving the existing ordinary-initialization-error
  cleanup behavior.

The change does not alter initialization or request-time cancellation behavior,
and externally managed sessions remain unaffected.

## Validation

- `python -m pytest tests/mcp_transport/test_base.py::TestMcpHttpTransportBase::test_close_managed_session_after_cancelled_initialization -v`
  - Before the fix: failed from `transport.close()` with
    `asyncio.exceptions.CancelledError`.
  - After the fix: `1 passed`.
- Test sensitivity: temporarily reverting only the production clause made the
  regression fail again; restoring it made the test pass.
- `python -m pytest tests/mcp_transport/test_base.py -q` — `39 passed`.
- `python -m pytest tests -q --ignore=tests/test_e2e.py --ignore=tests/test_sync_e2e.py --ignore=tests/test_e2e_mcp.py --ignore=tests/conformance --cov=src/toolbox_core --cov-report=term --cov-fail-under=90`
  — `482 passed`, total coverage `91.80%`.
- `python -m pytest tests/unit -q` in `toolbox-adk` — `59 passed`.
- `python -m pytest tests -k 'not e2e' -q` in `toolbox-langchain` —
  `60 passed`, `64 deselected`.
- `python -m pytest tests -k 'not e2e' -q` in `toolbox-llamaindex` —
  `61 passed`, `64 deselected`.
- `black --check .` — passed; `44 files would be left unchanged`.
- `isort --check .` — passed.
- `MYPYPATH='./src' mypy --install-types --non-interactive --cache-dir=<temporary-cache> -p toolbox_core`
  — `Success: no issues found in 29 source files`.
- `git diff upstream/main...HEAD --check` — passed.

Live E2E and conformance suites were not run locally because they require
external Toolbox/GCP infrastructure. Fork CI remains subject to the
repository's maintainer-triggered workflow.

## Compatibility and risk

The runtime change is limited to explicit cleanup after an initialization task
has already been cancelled. Ordinary initialization errors, successful
initialization, and unmanaged-session cleanup retain their existing behavior.

## Non-goals and related work

- This does not change request-time cancellation propagation or the shared
  initialization behavior addressed independently by #745. That PR explicitly
  lists changing `close()` cancellation semantics as a non-goal and modifies a
  different production hunk.
- This does not retry initialization, change protocol negotiation, or alter
  public APIs.
- This is independent of #735, #736, and #737 and does not touch their files or
  behaviors.

## AI assistance

AI assistance was used for repository inspection, implementation, testing, and
drafting this pull request. The contributor reviewed the final diff and
validation evidence.
