### PR TITLE
fix(core): strict 1:1 vendor prefix reading based on protocol version

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/transport_base.py
@@ -173,27 +173,24 @@ class _McpHttpTransportBase(ITransport, ABC):
                 self._protocol_version,
                 Protocol.MCP_v20260728.value,
             )
-            if (
-                is_2026_or_newer
-                and "com.google.cloud/authParam" in meta
-                and isinstance(meta["com.google.cloud/authParam"], dict)
-            ):
-                param_auth = meta["com.google.cloud/authParam"]
-            elif "toolbox/authParam" in meta and isinstance(
-                meta["toolbox/authParam"], dict
-            ):
-                param_auth = meta["toolbox/authParam"]
-
-            if (
-                is_2026_or_newer
-                and "com.google.cloud/authInvoke" in meta
-                and isinstance(meta["com.google.cloud/authInvoke"], list)
-            ):
-                invoke_auth = meta["com.google.cloud/authInvoke"]
-            elif "toolbox/authInvoke" in meta and isinstance(
-                meta["toolbox/authInvoke"], list
-            ):
-                invoke_auth = meta["toolbox/authInvoke"]
+            if is_2026_or_newer:
+                if "com.google.cloud/authParam" in meta and isinstance(
+                    meta["com.google.cloud/authParam"], dict
+                ):
+                    param_auth = meta["com.google.cloud/authParam"]
+                if "com.google.cloud/authInvoke" in meta and isinstance(
+                    meta["com.google.cloud/authInvoke"], list
+                ):
+                    invoke_auth = meta["com.google.cloud/authInvoke"]
+            else:
+                if "toolbox/authParam" in meta and isinstance(
+                    meta["toolbox/authParam"], dict
+                ):
+                    param_auth = meta["toolbox/authParam"]
+                if "toolbox/authInvoke" in meta and isinstance(
+                    meta["toolbox/authInvoke"], list
+                ):
+                    invoke_auth = meta["toolbox/authInvoke"]
 
         parameters = []
         input_schema = tool_data.get("inputSchema", {})

--- a/packages/toolbox-core/tests/mcp_transport/test_base.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_base.py
@@ -21,7 +21,7 @@ import pytest_asyncio
 from aiohttp import ClientSession
 
 from toolbox_core.mcp_transport.transport_base import _McpHttpTransportBase
-from toolbox_core.protocol import TelemetryAttributes, ToolSchema
+from toolbox_core.protocol import Protocol, TelemetryAttributes, ToolSchema
 
 
 class ConcreteTransport(_McpHttpTransportBase):
@@ -207,7 +207,8 @@ class TestMcpHttpTransportBase:
         assert p_obj.additionalProperties.type == "integer"
 
     def test_convert_tool_schema_with_auth_metadata(self, transport):
-        """Test converting tool schema with legacy toolbox auth metadata fields."""
+        """Test converting tool schema with legacy toolbox auth metadata fields on pre-2026 version."""
+        transport._protocol_version = Protocol.MCP_v20251125.value
         raw_tool = {
             "name": "auth_tool",
             "description": "Tool with auth params",
@@ -232,6 +233,7 @@ class TestMcpHttpTransportBase:
 
     def test_convert_tool_schema_with_com_google_cloud_auth_metadata(self, transport):
         """Test converting tool schema with 2026+ com.google.cloud auth metadata fields."""
+        transport._protocol_version = Protocol.MCP_v20260728.value
         raw_tool = {
             "name": "auth_tool_2026",
             "description": "Tool with 2026 auth params",
@@ -254,11 +256,12 @@ class TestMcpHttpTransportBase:
         p_api_key = next(p for p in schema.parameters if p.name == "apiKey")
         assert p_api_key.authSources == ["google-auth-source"]
 
-    def test_convert_tool_schema_auth_metadata_precedence(self, transport):
-        """Test that com.google.cloud vendor prefix takes precedence over legacy toolbox prefix."""
+    def test_convert_tool_schema_legacy_ignored_on_2026(self, transport):
+        """Test that legacy toolbox vendor prefix is ignored when active protocol version is 2026+."""
+        transport._protocol_version = Protocol.MCP_v20260728.value
         raw_tool = {
-            "name": "auth_tool_both",
-            "description": "Tool with both auth params",
+            "name": "auth_tool_legacy_on_2026",
+            "description": "Tool with legacy auth params on 2026 version",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -266,8 +269,6 @@ class TestMcpHttpTransportBase:
                 },
             },
             "_meta": {
-                "com.google.cloud/authParam": {"apiKey": ["primary-google-source"]},
-                "com.google.cloud/authInvoke": ["primary-google-invoke"],
                 "toolbox/authParam": {"apiKey": ["legacy-source"]},
                 "toolbox/authInvoke": ["legacy-invoke"],
             },
@@ -276,9 +277,9 @@ class TestMcpHttpTransportBase:
         schema = transport._convert_tool_schema(raw_tool)
 
         assert isinstance(schema, ToolSchema)
-        assert schema.authRequired == ["primary-google-invoke"]
+        assert schema.authRequired == []
         p_api_key = next(p for p in schema.parameters if p.name == "apiKey")
-        assert p_api_key.authSources == ["primary-google-source"]
+        assert p_api_key.authSources is None
 
     def test_convert_tool_schema_with_malformed_auth_metadata(self, transport):
         """Test robust handling of malformed or invalid types in _meta."""


### PR DESCRIPTION
## Overview
This PR refactors the metadata parsing logic in `_McpHttpTransportBase._convert_tool_schema` to enforce vendor prefix selection based on the active MCP protocol version.

## Problem
Previously, when processing tool metadata (`_meta`), if the active protocol version was `2026-07-28` or newer (`is_2026_or_newer`), the code attempted to read `com.google.cloud/` metadata first. However, if `com.google.cloud/` keys were absent, the `if / elif` chain fell through and read legacy `toolbox/` vendor prefix metadata (`toolbox/authParam` and `toolbox/authInvoke`). This allowed legacy metadata formats to inadvertently take effect on modern protocol versions.

## Solution
- Refactored `_convert_tool_schema` to strictly select vendor prefixes:
  - MCP 2026 only reads `com.google.cloud/authParam` and `com.google.cloud/authInvoke`.
    - Legacy `toolbox/` prefixes are ignored.
  - Pre 2026 MCP only reads `toolbox/authParam` and `toolbox/authInvoke`.

## Testing
  - Set `_protocol_version` (`MCP_v20251125` vs `MCP_v20260728`) across existing unit tests.
  - Updated `test_convert_tool_schema_legacy_ignored_on_2026` to verify that legacy `toolbox/` prefix metadata is strictly ignored when running on protocol version 2026+.
