### PR TITLE
chore(deps): update mcp toolbox server version in integration tests to v1.9.0

### DIFF
--- a/packages/toolbox-adk/integration.cloudbuild.yaml
+++ b/packages/toolbox-adk/integration.cloudbuild.yaml
@@ -50,5 +50,5 @@ options:
 substitutions:
   _VERSION: '3.13'
   # Default values (can be overridden by triggers)
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-core/integration.cloudbuild.yaml
+++ b/packages/toolbox-core/integration.cloudbuild.yaml
@@ -45,5 +45,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-core/tests/test_e2e.py
+++ b/packages/toolbox-core/tests/test_e2e.py
@@ -243,11 +243,8 @@ class TestAuth:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match="no field named row_data in claims",
-        ):
-            await tool()
+        response = await tool()
+        assert "no field named row_data in claims" in response
 
 
 @pytest.mark.asyncio

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -295,11 +295,8 @@ class TestAuth:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match="no field named row_data in claims",
-        ):
-            await tool()
+        response = await tool()
+        assert "no field named row_data in claims" in response
 
 
 @pytest.mark.asyncio

--- a/packages/toolbox-core/tests/test_sync_e2e.py
+++ b/packages/toolbox-core/tests/test_sync_e2e.py
@@ -199,8 +199,5 @@ class TestAuth:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match="no field named row_data in claims",
-        ):
-            tool()
+        response = tool()
+        assert "no field named row_data in claims" in response

--- a/packages/toolbox-langchain/integration.cloudbuild.yaml
+++ b/packages/toolbox-langchain/integration.cloudbuild.yaml
@@ -49,5 +49,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -213,11 +213,11 @@ class TestE2EClientAsync:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match='provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims',
-        ):
-            await tool.ainvoke({})
+        response = await tool.ainvoke({})
+        assert (
+            'provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims'
+            in response
+        )
 
 
 @pytest.mark.usefixtures("toolbox_server")
@@ -387,8 +387,8 @@ class TestE2EClientSync:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match='provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims',
-        ):
-            tool.invoke({})
+        response = tool.invoke({})
+        assert (
+            'provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims'
+            in response
+        )

--- a/packages/toolbox-llamaindex/integration.cloudbuild.yaml
+++ b/packages/toolbox-llamaindex/integration.cloudbuild.yaml
@@ -49,5 +49,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _VERSION: '3.13'
-  _TOOLBOX_VERSION: '1.8.0'
+  _TOOLBOX_VERSION: '1.9.0'
   _TOOLBOX_MANIFEST_VERSION: '34'

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -213,11 +213,11 @@ class TestE2EClientAsync:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match='provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims',
-        ):
-            await tool.acall()
+        response = await tool.acall()
+        assert (
+            'provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims'
+            in response.content
+        )
 
 
 @pytest.mark.usefixtures("toolbox_server")
@@ -387,8 +387,8 @@ class TestE2EClientSync:
             "get-row-by-content-auth",
             auth_token_getters={"my-test-auth": lambda: auth_token1},
         )
-        with pytest.raises(
-            Exception,
-            match='provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims',
-        ):
-            tool.call()
+        response = tool.call()
+        assert (
+            'provided parameters were invalid: error parsing authenticated parameter "data": no field named row_data in claims'
+            in response.content
+        )


### PR DESCRIPTION
## Description
Updates the MCP Toolbox server version used across all integration tests from `1.8.0` to `1.9.0` and updates test assertions for parameter validation errors.

## Context
Starting in MCP Toolbox server `v1.9.0`, parameter parsing and validation errors during tool execution conform to the Model Context Protocol specification:
- Errors originating during tool parameter parsing are now returned inside the JSON-RPC `result` object with `isError: true` instead of returning a top-level JSON-RPC protocol error (`-32602`).
- As a result, the SDK transport receives a valid tool result and returns the error message in the tool output string/content rather than raising an unhandled Python exception.

## Changes
- Bumped `_TOOLBOX_VERSION` to `'1.9.0'` in `integration.cloudbuild.yaml` for `toolbox-core`, `toolbox-langchain`, `toolbox-llamaindex`, and `toolbox-adk`.
- Updated tests to assert that the error string (`"no field named row_data in claims"`) is present in the returned response content instead of using `pytest.raises(Exception)`:
