### PR TITLE
fix(core): clean up draft protocol alias and remove hardcoded server version fallback

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260728/mcp.py
+++ b/packages/toolbox-core/src/toolbox_core/mcp_transport/v20260728/mcp.py
@@ -244,14 +244,15 @@ class McpHttpTransportV20260728(_McpHttpTransportBase):
 
             tools_map = {t["name"]: self._convert_tool_schema(t) for t in result.tools}
 
-            server_version = (
-                result.field_meta.server_info.version
-                if (result.field_meta and result.field_meta.server_info)
-                else "0.0.0"
-            )
+            if (
+                result.field_meta
+                and result.field_meta.server_info
+                and result.field_meta.server_info.version
+            ):
+                self._server_version = result.field_meta.server_info.version
 
             return ManifestSchema(
-                serverVersion=server_version,
+                serverVersion=self._server_version or "",
                 tools=tools_map,
             )
 

--- a/packages/toolbox-core/src/toolbox_core/protocol.py
+++ b/packages/toolbox-core/src/toolbox_core/protocol.py
@@ -52,7 +52,6 @@ class Protocol(str, Enum):
     MCP_v20241105 = "2024-11-05"
     MCP_v20251125 = "2025-11-25"
     MCP_v20260728 = "2026-07-28"
-    MCP_v2026_DRAFT = "2026-07-28"
 
     MCP = MCP_v20260728
     MCP_LATEST = MCP_v20260728

--- a/packages/toolbox-core/tests/mcp_transport/test_v20260728.py
+++ b/packages/toolbox-core/tests/mcp_transport/test_v20260728.py
@@ -547,7 +547,7 @@ class TestMcpHttpTransportV20260728:
         assert "sample_tool" in manifest.tools
 
     async def test_result_meta_optional_server_info(self, transport):
-        """Test that missing _meta or missing serverInfo falls back to default version '0.0.0'."""
+        """Test that missing _meta or missing serverInfo falls back to empty version."""
         mock_response = AsyncMock()
         mock_response.ok = True
         mock_response.status = 200
@@ -564,7 +564,7 @@ class TestMcpHttpTransportV20260728:
         transport._session.post.return_value.__aenter__.return_value = mock_response
 
         manifest = await transport.tools_list()
-        assert manifest.serverVersion == "0.0.0"
+        assert manifest.serverVersion == ""
 
     async def test_result_type_parsing_and_fallback(self, transport):
         """Test that resultType defaults to 'complete' if missing in response result."""


### PR DESCRIPTION
### Overview

- Cleaned up the deprecated `MCP_v2026_DRAFT` alias from `Protocol`.
- Removed the hardcoded `"0.0.0"` fallback for server version in `McpHttpTransportV20260728`, updating `self._server_version` only when metadata is provided and falling back to empty string `""`.
- Updated unit test assertions in `test_v20260728.py` to verify the empty fallback behavior.
