### PR TITLE
fix(ci): queue pending api-docs deploys instead of dropping them

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,12 +17,18 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main' ]
-    tags: [ '**' ]
+    # release-please pushes this alongside each release; it builds nothing and
+    # only costs a queue slot.
+    tags-ignore: [ 'release-please-*' ]
   workflow_dispatch:
 
+# One group: runs share the site root and each package's releases/latest files,
+# and the deploy action pushes without retrying. queue: max holds 100 pending
+# runs; the default of 1 silently dropped seven released versions.
 concurrency:
   group: api-docs-deploy
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:
@@ -33,7 +39,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
           fetch-depth: 0
@@ -73,7 +79,8 @@ jobs:
           # Route the git ref to the package(s) and version to build.
           # A per-package tag builds that one package; pushes to main (and manual
           # dispatch) build all four as "dev". Python release tags are
-          # toolbox-<name>-vX.Y.Z; release-please-* and any other tag are skipped.
+          # toolbox-<name>-vX.Y.Z; any other tag resolves to no package and
+          # skips the build.
           REF="${GITHUB_REF}"
           case "$REF" in
             refs/tags/toolbox-core-v*)       echo "packages=core"                          >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/toolbox-core-}"       >> "$GITHUB_OUTPUT" ;;


### PR DESCRIPTION
Replicates https://github.com/googleapis/mcp-toolbox-sdk-js/pull/444

## Why

The `api-docs-deploy` concurrency group uses the default queue, which holds only **one** pending run — so a third push cancels the second before it starts, with no failed job and no red check.

release-please pushes three refs per release (the `main` merge commit, the version tag, and a `release-please-*` tag), so the version tag's run is the one evicted. Five such cancellations are visible in the last 40 runs, and **seven released versions are missing** from https://py.mcp-toolbox.dev/: core v1.2.0/v1.3.0, adk v1.2.0/v1.3.1, langchain v1.2.0/v1.3.0, llamaindex v0.8.0.

## What

- **`queue: max`** — queues up to 100 pending runs in FIFO instead of 1. This matters more here than in the JS repo: four packages means up to eight contending refs per simultaneous release.
- **Keep the shared group** — the deploy action pushes without retrying, and runs share the site root and the per-package `releases.releases` / `latest/` files, so serializing keeps last-writer-wins deterministic.
- **`tags-ignore: release-please-*`** — that run builds nothing and only costs a queue slot.
- Stale `actions/checkout` comment `# v7` → `# v7.0.0`. Pinned commit unchanged.

Verified on the JS repo with a live A/B test: under three pushes 20s apart, `queue: max` ran 3/3 while the default `single` cancelled the middle run.

The seven missing versions need separate `api-docs-backfill` runs; this PR only stops the bleeding.
