### PR TITLE
test: add cross-binding mutual exclusivity E2E tests

### DIFF
--- a/packages/toolbox-adk/tests/integration/test_integration.py
+++ b/packages/toolbox-adk/tests/integration/test_integration.py
@@ -1022,3 +1022,45 @@ class TestSecureParamsE2E:
             assert "name" not in declaration.parameters.properties
         finally:
             await toolset.close()
+
+    @pytest.mark.parametrize(
+        ("method_name", "param_name", "param_val", "expected_match"),
+        [
+            (
+                "bind_param",
+                "name",
+                "Alice",
+                "parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead",
+            ),
+            (
+                "bind_secure_param",
+                "id",
+                1,
+                "parameter 'id' is a regular parameter; use bind_param/bind_params instead",
+            ),
+        ],
+    )
+    async def test_adk_cross_binding_guidance_error(
+        self,
+        method_name,
+        param_name,
+        param_val,
+        expected_match,
+    ):
+        """Tests that cross-binding on ADK tool raises guidance error."""
+        toolset = ToolboxToolset(
+            server_url=TOOLBOX_SERVER_URL_STABLE,
+            toolset_name="my-secure-toolset",
+            credentials=CredentialStrategy.toolbox_identity(),
+        )
+        try:
+            tools = await toolset.get_tools()
+            by_name = {t.name: t for t in tools}
+            if "my-secure-tool" not in by_name:
+                pytest.skip("my-secure-tool not found in my-secure-toolset")
+            tool = by_name["my-secure-tool"]
+            method = getattr(tool, method_name)
+            with pytest.raises(ValueError, match=expected_match):
+                method(param_name, param_val)
+        finally:
+            await toolset.close()

--- a/packages/toolbox-core/tests/test_e2e_mcp.py
+++ b/packages/toolbox-core/tests/test_e2e_mcp.py
@@ -749,3 +749,42 @@ class TestSecureParamsE2E:
         assert "id" in sig.parameters
         assert "name" not in sig.parameters
         assert "name" not in (tool.__doc__ or "")
+
+    @pytest.mark.parametrize(
+        ("method_name", "param_name", "param_val", "expected_match"),
+        [
+            (
+                "bind_param",
+                "name",
+                "Alice",
+                "parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead",
+            ),
+            (
+                "bind_secure_param",
+                "id",
+                1,
+                "parameter 'id' is a regular parameter; use bind_param/bind_params instead",
+            ),
+        ],
+    )
+    async def test_cross_binding_guidance_error(
+        self,
+        toolbox: ToolboxClient,
+        method_name: str,
+        param_name: str,
+        param_val: Any,
+        expected_match: str,
+    ):
+        """Tests that cross-binding (bind_param on secure or bind_secure_param on regular) raises guidance error."""
+        protocol_version = toolbox._ToolboxClient__transport._protocol_version
+        if not Protocol._is_version_at_least(
+            protocol_version, Protocol.MCP_v20260728.value
+        ):
+            with pytest.raises(ValueError, match="Tool 'my-secure-tool' not found"):
+                await toolbox.load_tool("my-secure-tool")
+            return
+
+        tool = await toolbox.load_tool("my-secure-tool")
+        method = getattr(tool, method_name)
+        with pytest.raises(ValueError, match=expected_match):
+            method(param_name, param_val)

--- a/packages/toolbox-langchain/tests/test_e2e.py
+++ b/packages/toolbox-langchain/tests/test_e2e.py
@@ -422,3 +422,64 @@ class TestSecureParamsE2E:
             assert "Alice" in response
         finally:
             toolbox.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "param_name", "param_val", "expected_match"),
+        [
+            (
+                "bind_param",
+                "name",
+                "Alice",
+                "parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead",
+            ),
+            (
+                "bind_secure_param",
+                "id",
+                1,
+                "parameter 'id' is a regular parameter; use bind_param/bind_params instead",
+            ),
+        ],
+    )
+    async def test_async_cross_binding_guidance_error(
+        self, method_name, param_name, param_val, expected_match
+    ):
+        """Tests that cross-binding on LangChain async tool raises guidance error."""
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
+        try:
+            tool = await toolbox.aload_tool("my-secure-tool")
+            method = getattr(tool, method_name)
+            with pytest.raises(ValueError, match=expected_match):
+                method(param_name, param_val)
+        finally:
+            toolbox.close()
+
+    @pytest.mark.parametrize(
+        ("method_name", "param_name", "param_val", "expected_match"),
+        [
+            (
+                "bind_param",
+                "name",
+                "Alice",
+                "parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead",
+            ),
+            (
+                "bind_secure_param",
+                "id",
+                1,
+                "parameter 'id' is a regular parameter; use bind_param/bind_params instead",
+            ),
+        ],
+    )
+    def test_sync_cross_binding_guidance_error(
+        self, method_name, param_name, param_val, expected_match
+    ):
+        """Tests that cross-binding on LangChain sync tool raises guidance error."""
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
+        try:
+            tool = toolbox.load_tool("my-secure-tool")
+            method = getattr(tool, method_name)
+            with pytest.raises(ValueError, match=expected_match):
+                method(param_name, param_val)
+        finally:
+            toolbox.close()

--- a/packages/toolbox-llamaindex/tests/test_e2e.py
+++ b/packages/toolbox-llamaindex/tests/test_e2e.py
@@ -422,3 +422,64 @@ class TestSecureParamsE2E:
             assert "Alice" in response.content
         finally:
             toolbox.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "param_name", "param_val", "expected_match"),
+        [
+            (
+                "bind_param",
+                "name",
+                "Alice",
+                "parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead",
+            ),
+            (
+                "bind_secure_param",
+                "id",
+                1,
+                "parameter 'id' is a regular parameter; use bind_param/bind_params instead",
+            ),
+        ],
+    )
+    async def test_async_cross_binding_guidance_error(
+        self, method_name, param_name, param_val, expected_match
+    ):
+        """Tests that cross-binding on LlamaIndex async tool raises guidance error."""
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
+        try:
+            tool = await toolbox.aload_tool("my-secure-tool")
+            method = getattr(tool, method_name)
+            with pytest.raises(ValueError, match=expected_match):
+                method(param_name, param_val)
+        finally:
+            toolbox.close()
+
+    @pytest.mark.parametrize(
+        ("method_name", "param_name", "param_val", "expected_match"),
+        [
+            (
+                "bind_param",
+                "name",
+                "Alice",
+                "parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead",
+            ),
+            (
+                "bind_secure_param",
+                "id",
+                1,
+                "parameter 'id' is a regular parameter; use bind_param/bind_params instead",
+            ),
+        ],
+    )
+    def test_sync_cross_binding_guidance_error(
+        self, method_name, param_name, param_val, expected_match
+    ):
+        """Tests that cross-binding on LlamaIndex sync tool raises guidance error."""
+        toolbox = ToolboxClient(TOOLBOX_SERVER_URL_STABLE)
+        try:
+            tool = toolbox.load_tool("my-secure-tool")
+            method = getattr(tool, method_name)
+            with pytest.raises(ValueError, match=expected_match):
+                method(param_name, param_val)
+        finally:
+            toolbox.close()


### PR DESCRIPTION
### Overview
This PR adds E2E integration tests verifying parameter binding mutual exclusivity and guidance error messages across packages, achieving parity with the test suites in JS and Go SDKs.

### Tests Added
1. Attempting to call `bind_param()` on a secure parameter (e.g. `name` on `my-secure-tool`) fails with the expected guidance:
   `parameter 'name' is a secure parameter; use bind_secure_param/bind_secure_params instead`
2. Attempting to call `bind_secure_param()` on a regular parameter (e.g. `id` on `my-secure-tool`) fails with the expected guidance:
   `parameter 'id' is a regular parameter; use bind_param/bind_params instead`

> [!NOTE]
> This is a follow up PR from https://github.com/googleapis/mcp-toolbox-sdk-python/pull/782.